### PR TITLE
🚨 EMERGENCY: Fix Vercel deployment - Correct app directory configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "yalla-london-root",
+  "private": true,
+  "scripts": {
+    "build": "cd yalla_london/app && npm run build",
+    "dev": "cd yalla_london/app && npm run dev",
+    "start": "cd yalla_london/app && npm run start",
+    "install-app": "cd yalla_london/app && npm install"
+  },
+  "workspaces": [
+    "yalla_london/app"
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "buildCommand": "cd yalla_london/app && npm run build",
+  "devCommand": "cd yalla_london/app && npm run dev",
+  "installCommand": "cd yalla_london/app && npm install",
+  "outputDirectory": "yalla_london/app/.next",
+  "framework": "nextjs",
+  "rootDirectory": "yalla_london/app"
+}


### PR DESCRIPTION
## 🚨 EMERGENCY FIX: Vercel Deployment Issue

### Root Cause Analysis
After deep investigation, I discovered the real issue causing the shadcn/ui component resolution failures:

1. **Missing Branch**: The "fix-explicit-paths" branch that Vercel was trying to deploy **didn't exist**
2. **Wrong Build Directory**: Vercel was trying to build from the repository root, but the actual Next.js app is located in `yalla_london/app/`
3. **Component Location Mismatch**: The shadcn/ui components exist at `yalla_london/app/components/ui/` but Vercel was looking in the wrong directory

### What This PR Fixes

✅ **Added `vercel.json`** - Configures Vercel to:
- Build from the correct directory (`yalla_london/app`)
- Use the right build commands
- Point to the correct output directory

✅ **Added root `package.json`** - Sets up workspace configuration for proper dependency resolution

✅ **Created missing `fix-explicit-paths` branch** - The branch Vercel was expecting now exists

### Files Changed
- `vercel.json` - Vercel deployment configuration
- `package.json` - Root workspace configuration

### Expected Result
- ✅ Vercel will now build from the correct directory
- ✅ shadcn/ui components will resolve properly (`@/components/ui/button`, `@/components/ui/card`, etc.)
- ✅ Deployment should succeed

### Verification
The components DO exist at the correct locations:
- `yalla_london/app/components/ui/button.tsx` ✅
- `yalla_london/app/components/ui/card.tsx` ✅
- All other shadcn/ui components ✅

The tsconfig.json path mapping (`"@/*": ["./*"]`) is correct for the app directory.

**This should resolve the deployment issue immediately.**