### PR TITLE
fix(seo): Product schema alignment with Google Merchant Listings spec

### DIFF
--- a/.claude/logs/sessions/2026-04-18_07-33.md
+++ b/.claude/logs/sessions/2026-04-18_07-33.md
@@ -1,0 +1,9 @@
+# Session Log: 2026-04-18_07-33
+- **Session ID:** 4527c898-9447-4c1c-b16f-e937328ae070
+- **Branch:** claude/new-session-ini84
+- **Uncommitted changes:** 0
+
+## Changes
+```
+
+```

--- a/.claude/logs/sessions/2026-04-18_07-38.md
+++ b/.claude/logs/sessions/2026-04-18_07-38.md
@@ -1,10 +1,9 @@
 # Session Log: 2026-04-18_07-38
 - **Session ID:** 4527c898-9447-4c1c-b16f-e937328ae070
 - **Branch:** claude/new-session-ini84
-- **Uncommitted changes:** 2
+- **Uncommitted changes:** 0
 
 ## Changes
 ```
- PROJECT_STATUS.md | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+
 ```

--- a/.claude/logs/sessions/2026-04-18_07-38.md
+++ b/.claude/logs/sessions/2026-04-18_07-38.md
@@ -1,0 +1,10 @@
+# Session Log: 2026-04-18_07-38
+- **Session ID:** 4527c898-9447-4c1c-b16f-e937328ae070
+- **Branch:** claude/new-session-ini84
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ PROJECT_STATUS.md | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+```

--- a/.claude/logs/sessions/2026-04-18_07-43.md
+++ b/.claude/logs/sessions/2026-04-18_07-43.md
@@ -1,0 +1,11 @@
+# Session Log: 2026-04-18_07-43
+- **Session ID:** 4527c898-9447-4c1c-b16f-e937328ae070
+- **Branch:** claude/new-session-ini84
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ .claude/logs/sessions/2026-04-18_07-38.md | 5 ++---
+ PROJECT_STATUS.md                         | 2 +-
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+```

--- a/.claude/logs/sessions/2026-04-18_07-44.md
+++ b/.claude/logs/sessions/2026-04-18_07-44.md
@@ -1,0 +1,9 @@
+# Session Log: 2026-04-18_07-44
+- **Session ID:** 4527c898-9447-4c1c-b16f-e937328ae070
+- **Branch:** claude/new-session-ini84
+- **Uncommitted changes:** 0
+
+## Changes
+```
+
+```

--- a/.claude/logs/sessions/2026-04-18_07-53.md
+++ b/.claude/logs/sessions/2026-04-18_07-53.md
@@ -1,0 +1,9 @@
+# Session Log: 2026-04-18_07-53
+- **Session ID:** 4527c898-9447-4c1c-b16f-e937328ae070
+- **Branch:** claude/new-session-ini84
+- **Uncommitted changes:** 0
+
+## Changes
+```
+
+```

--- a/.claude/logs/sessions/2026-04-18_08-04.md
+++ b/.claude/logs/sessions/2026-04-18_08-04.md
@@ -1,0 +1,9 @@
+# Session Log: 2026-04-18_08-04
+- **Session ID:** 4527c898-9447-4c1c-b16f-e937328ae070
+- **Branch:** claude/new-session-ini84
+- **Uncommitted changes:** 0
+
+## Changes
+```
+
+```

--- a/.claude/logs/sessions/2026-04-18_09-04.md
+++ b/.claude/logs/sessions/2026-04-18_09-04.md
@@ -1,0 +1,9 @@
+# Session Log: 2026-04-18_09-04
+- **Session ID:** aa1cc7c6-b243-42a4-93b5-888aaaa6d293
+- **Branch:** claude/new-session-ini84
+- **Uncommitted changes:** 0
+
+## Changes
+```
+
+```

--- a/.claude/logs/sessions/2026-04-18_09-07.md
+++ b/.claude/logs/sessions/2026-04-18_09-07.md
@@ -1,0 +1,10 @@
+# Session Log: 2026-04-18_09-07
+- **Session ID:** aa1cc7c6-b243-42a4-93b5-888aaaa6d293
+- **Branch:** claude/new-session-ini84
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ PROJECT_STATUS.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+```

--- a/.claude/logs/sessions/2026-04-18_09-08.md
+++ b/.claude/logs/sessions/2026-04-18_09-08.md
@@ -1,0 +1,9 @@
+# Session Log: 2026-04-18_09-08
+- **Session ID:** aa1cc7c6-b243-42a4-93b5-888aaaa6d293
+- **Branch:** claude/new-session-ini84
+- **Uncommitted changes:** 0
+
+## Changes
+```
+
+```

--- a/.claude/logs/sessions/2026-04-18_09-10.md
+++ b/.claude/logs/sessions/2026-04-18_09-10.md
@@ -1,0 +1,10 @@
+# Session Log: 2026-04-18_09-10
+- **Session ID:** aa1cc7c6-b243-42a4-93b5-888aaaa6d293
+- **Branch:** claude/new-session-ini84
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ PROJECT_STATUS.md | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+```

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-18 09:07 UTC
+- Date: 2026-04-18 09:10 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,10 +2,10 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-18 07:43 UTC
+- Date: 2026-04-18 07:44 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
-- Files changed: 2 files
+- Files changed: 0 files
 
 ## Active Branches
 | Branch | Purpose | Status |

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-18 07:44 UTC
+- Date: 2026-04-18 07:53 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 0 files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,10 +2,10 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-18 08:04 UTC
+- Date: 2026-04-18 09:07 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
-- Files changed: 0 files
+- Files changed: 2 files
 
 ## Active Branches
 | Branch | Purpose | Status |

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-18 07:53 UTC
+- Date: 2026-04-18 08:04 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 0 files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-18 07:38 UTC
+- Date: 2026-04-18 07:43 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-11 09:52 UTC
+- Date: 2026-04-18 07:38 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/yalla_london/app/app/about/layout.tsx
+++ b/yalla_london/app/app/about/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, isYachtSite as checkIsYachtSite } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,7 +13,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
   const destination = siteConfig?.destination || "London";
-  const canonicalUrl = await getLocaleAwareCanonical("/about");
+  const alternates = await getLocaleAlternates("/about");
+  const canonicalUrl = alternates.canonical;
 
   // Yacht-specific metadata
   if (checkIsYachtSite(siteId)) {
@@ -21,14 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: "About Zenitha Yachts | Luxury Yacht Charters",
       description:
         "Discover the Zenitha Yachts story. We curate exceptional Mediterranean yacht charter experiences for discerning GCC travellers, with halal-certified options and personalised service.",
-      alternates: {
-        canonical: canonicalUrl,
-        languages: {
-          "en-GB": canonicalUrl,
-          "ar-SA": `${baseUrl}/ar/about`,
-          "x-default": canonicalUrl,
-        },
-      },
+      alternates,
       openGraph: {
         title: "About Zenitha Yachts | Luxury Yacht Charters",
         description:
@@ -64,14 +58,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: `About ${siteName} | ${destination} Travel Guide for Arab Visitors`,
     description: `About ${siteName} — your premium ${destination} travel guide for Arab visitors. Discover our story, mission, team, and commitment to luxury travel.`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/about`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `About ${siteName} | ${destination} Travel Guide for Arab Visitors`,
       description: `About ${siteName} — your premium ${destination} travel guide for Arab visitors. Discover our story, mission, team, and commitment to luxury travel.`,

--- a/yalla_london/app/app/affiliate-disclosure/layout.tsx
+++ b/yalla_london/app/app/affiliate-disclosure/layout.tsx
@@ -1,30 +1,22 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig } from "@/config/sites";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const baseUrl = await getBaseUrl();
   const headersList = await headers();
   const siteId = headersList.get("x-site-id") || getDefaultSiteId();
   const siteConfig = getSiteConfig(siteId);
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
-  const destination = siteConfig?.destination || "London";
-  const canonicalUrl = await getLocaleAwareCanonical("/affiliate-disclosure");
+  const alternates = await getLocaleAlternates("/affiliate-disclosure");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `Affiliate Disclosure | ${siteName}`,
     description: `${siteName} affiliate disclosure. Transparency about our affiliate partnerships, how we earn commissions, and our editorial independence policy.`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/affiliate-disclosure`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `Affiliate Disclosure | ${siteName}`,
       description: `${siteName} affiliate disclosure. Transparency about our affiliate partnerships, how we earn commissions, and our editorial independence policy.`,

--- a/yalla_london/app/app/blog/[slug]/page.tsx
+++ b/yalla_london/app/app/blog/[slug]/page.tsx
@@ -233,13 +233,23 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   // Arabic SSR: detect locale from middleware header so crawlers on /ar/ routes
   // see Arabic metadata in the HTML head (not just after client hydration).
-  const locale = headersList.get("x-locale") || "en";
-  const isArabic = locale === "ar";
+  // Effective locale = URL path locale OR the site's primary locale, so
+  // AR-primary sites (arabaldives) render Arabic at root URLs.
+  const pathLocale = headersList.get("x-locale") === "ar" ? "ar" : "en";
+  const sitePrimaryLocale = (headersList.get("x-site-locale") === "ar"
+    ? "ar"
+    : siteConfig?.locale === "ar" ? "ar" : "en") as "en" | "ar";
+  const isArabic = pathLocale === "ar" || (pathLocale === "en" && sitePrimaryLocale === "ar");
+  const locale = isArabic ? "ar" : "en";
 
-  // Locale-aware canonical: /ar/blog/slug for Arabic, /blog/slug for English.
+  // Per-site URL structure: AR-primary sites put AR at root, EN fallback under /en/*.
   // Google requires canonical to match the URL being crawled.
-  const enUrl = `${baseUrl}/blog/${slug}`;
-  const arUrl = `${baseUrl}/ar/blog/${slug}`;
+  const enUrl = sitePrimaryLocale === "ar"
+    ? `${baseUrl}/en/blog/${slug}`
+    : `${baseUrl}/blog/${slug}`;
+  const arUrl = sitePrimaryLocale === "ar"
+    ? `${baseUrl}/blog/${slug}`
+    : `${baseUrl}/ar/blog/${slug}`;
   const canonicalUrl = isArabic ? arUrl : enUrl;
 
   const result = await findPost(slug, siteId);
@@ -326,11 +336,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     publisher: siteName,
     alternates: {
       canonical: canonicalUrl,
-      languages: {
-        "en-GB": enUrl,
-        "ar-SA": arUrl,
-        "x-default": enUrl,
-      },
+      languages: sitePrimaryLocale === "ar"
+        // AR-primary: skip en-GB — /en/blog/X does not yet exist.
+        ? { "ar-SA": arUrl, "x-default": arUrl }
+        : { "en-GB": enUrl, "ar-SA": arUrl, "x-default": enUrl },
     },
     openGraph: {
       title,

--- a/yalla_london/app/app/blog/category/[slug]/page.tsx
+++ b/yalla_london/app/app/blog/category/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { blogPosts, categories } from "@/data/blog-content";
 import { extendedBlogPosts } from "@/data/blog-content-extended";
 import { getDefaultSiteId, getSiteConfig, getSiteDomain, isYachtSite } from "@/config/sites";
+import { getLocaleAlternates } from "@/lib/url-utils";
 import BlogListClient from "../../BlogListClient";
 
 const allStaticPosts = [...blogPosts, ...extendedBlogPosts];
@@ -30,18 +31,13 @@ export async function generateMetadata({ params }: CategoryPageProps): Promise<M
   const siteName = siteConfig?.name || "Yalla London";
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || getSiteDomain(siteId);
 
+  const alternates = await getLocaleAlternates(`/blog/category/${slug}`);
+
   return {
     title: `${category.name_en} | ${siteName} Blog`,
     description: category.description_en,
     keywords: (category as any).keywords?.join(", "),
-    alternates: {
-      canonical: `${baseUrl}/blog/category/${slug}`,
-      languages: {
-        "en-GB": `${baseUrl}/blog/category/${slug}`,
-        "ar-SA": `${baseUrl}/ar/blog/category/${slug}`,
-        "x-default": `${baseUrl}/blog/category/${slug}`,
-      },
-    },
+    alternates,
     openGraph: {
       title: `${category.name_en} | ${siteName} Blog`,
       description: category.description_en,

--- a/yalla_london/app/app/blog/page.tsx
+++ b/yalla_london/app/app/blog/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import { headers } from "next/headers";
 import { blogPosts, categories } from "@/data/blog-content";
 import { extendedBlogPosts } from "@/data/blog-content-extended";
-import { getBaseUrl } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getSiteDomain, getSiteConfig, getDefaultSiteId } from "@/config/sites";
 import BlogListClient from "./BlogListClient";
 
@@ -31,18 +31,13 @@ export async function generateMetadata({
   const params = await searchParams;
   const hasTagFilter = !!params?.tag;
 
+  const alternates = await getLocaleAlternates("/blog");
+
   return {
     title: `Blog | ${siteName} — Travel Guides & Tips`,
     description: `Travel guides, restaurant reviews, and insider tips for Arab visitors to ${destination}. Halal dining, luxury hotels, and exclusive experiences.`,
     keywords: `${destination.toLowerCase()} blog, halal travel ${destination.toLowerCase()}, arab visitors ${destination.toLowerCase()}, ${destination.toLowerCase()} guides`,
-    alternates: {
-      canonical: `${baseUrl}/blog`,
-      languages: {
-        "en-GB": `${baseUrl}/blog`,
-        "ar-SA": `${baseUrl}/ar/blog`,
-        "x-default": `${baseUrl}/blog`,
-      },
-    },
+    alternates,
     openGraph: {
       title: `Blog | ${siteName} - Travel Guides for Arab Visitors`,
       description: `Discover ${destination} through the eyes of Arab travelers. Halal dining, luxury hotels, shopping guides, and cultural experiences.`,

--- a/yalla_london/app/app/brands/page.tsx
+++ b/yalla_london/app/app/brands/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { ZenithaLuxuryHomepage } from "@/components/zenitha-luxury/zenitha-luxury-homepage";
 
 export const dynamic = "force-dynamic";
@@ -11,17 +11,12 @@ export async function generateMetadata(): Promise<Metadata> {
   const description =
     "Explore the Zenitha portfolio: Yalla London, Zenitha Yachts, Arabaldives, Yalla Riviera, Yalla Istanbul, and Yalla Thailand.";
 
+  const alternates = await getLocaleAlternates("/brands");
+
   return {
     title,
     description,
-    alternates: {
-      canonical: `${baseUrl}/brands`,
-      languages: {
-        "en-GB": `${baseUrl}/brands`,
-        "ar-SA": `${baseUrl}/ar/brands`,
-        "x-default": `${baseUrl}/brands`,
-      },
-    },
+    alternates,
     openGraph: {
       title,
       description,

--- a/yalla_london/app/app/charter-planner/layout.tsx
+++ b/yalla_london/app/app/charter-planner/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,7 +13,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Zenitha Yachts";
   const siteSlug = siteConfig?.slug || "zenitha-yachts";
   const siteDomain = getSiteDomain(siteId);
-  const canonicalUrl = await getLocaleAwareCanonical("/charter-planner");
+  const alternates = await getLocaleAlternates("/charter-planner");
+  const canonicalUrl = alternates.canonical;
 
   const title = `AI Charter Planner | ${siteName}`;
   const description =
@@ -22,14 +23,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title,
     description,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/charter-planner`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title,
       description,

--- a/yalla_london/app/app/contact/layout.tsx
+++ b/yalla_london/app/app/contact/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, isYachtSite as checkIsYachtSite } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,7 +13,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
   const destination = siteConfig?.destination || "London";
-  const canonicalUrl = await getLocaleAwareCanonical("/contact");
+  const alternates = await getLocaleAlternates("/contact");
+  const canonicalUrl = alternates.canonical;
 
   // Yacht-specific metadata
   if (checkIsYachtSite(siteId)) {
@@ -21,14 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: "Contact Zenitha Yachts | Charter Inquiries & Support",
       description:
         "Get in touch with Zenitha Yachts for Mediterranean yacht charter inquiries, destination questions, partnerships, or press. WhatsApp, email, or phone — we respond within 24 hours.",
-      alternates: {
-        canonical: canonicalUrl,
-        languages: {
-          "en-GB": canonicalUrl,
-          "ar-SA": `${baseUrl}/ar/contact`,
-          "x-default": canonicalUrl,
-        },
-      },
+      alternates,
       openGraph: {
         title: "Contact Zenitha Yachts | Charter Inquiries & Support",
         description:
@@ -64,14 +58,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: `Contact Us — Get in Touch | ${siteName}`,
     description: `Reach the ${siteName} team for ${destination} travel questions, partnerships, advertising, or feedback. We'd love to hear from you.`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/contact`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `Contact Us | ${siteName}`,
       description: `Reach the ${siteName} team for ${destination} travel questions, partnerships, advertising, or feedback. We'd love to hear from you.`,

--- a/yalla_london/app/app/destinations/[slug]/page.tsx
+++ b/yalla_london/app/app/destinations/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { headers } from "next/headers";
 import Link from "next/link";
 import Image from "next/image";
 import { notFound } from "next/navigation";
-import { getBaseUrl } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDescription } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 import {
@@ -116,19 +116,13 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     console.warn("[destination-detail] metadata DB query failed:", e);
   }
 
-  const canonicalUrl = `${baseUrl}/destinations/${slug}`;
+  const alternates = await getLocaleAlternates(`/destinations/${slug}`);
+  const canonicalUrl = alternates.canonical;
 
   return {
     title,
     description,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/destinations/${slug}`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title,
       description,

--- a/yalla_london/app/app/destinations/layout.tsx
+++ b/yalla_london/app/app/destinations/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,20 +13,14 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Zenitha Yachts";
   const siteSlug = siteConfig?.slug || "zenitha-yachts";
   const siteDomain = getSiteDomain(siteId);
-  const canonicalUrl = await getLocaleAwareCanonical("/destinations");
+  const alternates = await getLocaleAlternates("/destinations");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `Yacht Charter Destinations | ${siteName}`,
     description:
       "Explore premier yacht charter destinations across the Mediterranean, Arabian Gulf, and Red Sea. Curated sailing guides, marina info, and seasonal advice for discerning charterers.",
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/destinations`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `Yacht Charter Destinations | ${siteName}`,
       description:

--- a/yalla_london/app/app/destinations/page.tsx
+++ b/yalla_london/app/app/destinations/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import { headers } from "next/headers";
 import Link from "next/link";
 
-import { getBaseUrl } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from "@/config/sites";
 import {
   Anchor,
@@ -180,20 +180,14 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteId = headersList.get("x-site-id") || getDefaultSiteId();
   const siteConfig = getSiteConfig(siteId);
   const siteName = siteConfig?.name || "Zenitha Yachts";
-  const canonicalUrl = `${baseUrl}/destinations`;
+  const alternates = await getLocaleAlternates("/destinations");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `Yacht Charter Destinations | ${siteName}`,
     description:
       "Discover the finest yacht charter destinations across the Mediterranean, Arabian Gulf, and Red Sea. Greek Islands, Croatian Coast, Turkish Riviera, and more.",
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/destinations`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `Yacht Charter Destinations | ${siteName}`,
       description:

--- a/yalla_london/app/app/editorial-policy/layout.tsx
+++ b/yalla_london/app/app/editorial-policy/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -12,19 +12,13 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteConfig = getSiteConfig(siteId);
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
-  const canonicalUrl = await getLocaleAwareCanonical("/editorial-policy");
+  const alternates = await getLocaleAlternates("/editorial-policy");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `Editorial Policy — Content Standards & Fact-Checking | ${siteName}`,
     description: `${siteName}'s editorial policy: how we research, write, fact-check, and update our content. Our commitment to accuracy, transparency, and first-hand experience.`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/editorial-policy`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `Editorial Policy | ${siteName}`,
       description: `${siteName}'s editorial policy: how we research, write, fact-check, and update our content.`,

--- a/yalla_london/app/app/events/layout.tsx
+++ b/yalla_london/app/app/events/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,19 +13,14 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
   const destination = siteConfig?.destination || "London";
-  const canonicalUrl = await getLocaleAwareCanonical("/events");
+  // Locale + site-primary-locale-aware alternates.
+  const alternates = await getLocaleAlternates("/events");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `${destination} Events & Shows | ${siteName}`,
     description: `Discover the best events, shows, exhibitions, and experiences in ${destination}. Book tickets for theatre, football, festivals, and exclusive VIP experiences.`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/events`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `${destination} Events & Shows | ${siteName}`,
       description: `Discover the best events, shows, exhibitions, and experiences in ${destination}. Book tickets for theatre, football, festivals, and exclusive VIP experiences.`,

--- a/yalla_london/app/app/experiences/layout.tsx
+++ b/yalla_london/app/app/experiences/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,19 +13,14 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
   const destination = siteConfig?.destination || "London";
-  const canonicalUrl = await getLocaleAwareCanonical("/experiences");
+  // Locale + site-primary-locale-aware alternates.
+  const alternates = await getLocaleAlternates("/experiences");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `${destination} Experiences & Tours | ${siteName}`,
     description: `Book the best tours, attractions, and experiences in ${destination}. From iconic landmarks to hidden gems — curated for Arab visitors with halal-friendly options.`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/experiences`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `${destination} Experiences & Tours | ${siteName}`,
       description: `Book the best tours, attractions, and experiences in ${destination}. From iconic landmarks to hidden gems — curated for Arab visitors with halal-friendly options.`,

--- a/yalla_london/app/app/faq/layout.tsx
+++ b/yalla_london/app/app/faq/layout.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Metadata } from 'next';
 import { headers } from 'next/headers';
-import { getBaseUrl, getLocaleAwareCanonical } from '@/lib/url-utils';
+import { getBaseUrl, getLocaleAlternates } from '@/lib/url-utils';
 import {
   getDefaultSiteId,
   getSiteConfig,
@@ -28,21 +28,17 @@ export async function generateMetadata(): Promise<Metadata> {
     ? 'Answers to common questions about yacht charter booking, halal catering, Mediterranean destinations, costs, and what to expect on your sailing holiday.'
     : `Frequently asked questions about ${siteName}. Find answers to common queries about our services, content, and travel recommendations.`;
 
+  const alternates = await getLocaleAlternates('/faq');
+  const canonicalUrl = alternates.canonical;
+
   return {
     title,
     description,
-    alternates: {
-      canonical: await getLocaleAwareCanonical('/faq'),
-      languages: {
-        'en-GB': await getLocaleAwareCanonical('/faq'),
-        'ar-SA': `${baseUrl}/ar/faq`,
-        'x-default': await getLocaleAwareCanonical('/faq'),
-      },
-    },
+    alternates,
     openGraph: {
       title,
       description,
-      url: await getLocaleAwareCanonical('/faq'),
+      url: canonicalUrl,
       siteName,
       type: 'website',
       locale: 'en_GB',

--- a/yalla_london/app/app/fleet/layout.tsx
+++ b/yalla_london/app/app/fleet/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,7 +13,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Zenitha Yachts";
   const siteSlug = siteConfig?.slug || "zenitha-yachts";
   const siteDomain = getSiteDomain(siteId);
-  const canonicalUrl = await getLocaleAwareCanonical("/fleet");
+  const alternates = await getLocaleAlternates("/fleet");
+  const canonicalUrl = alternates.canonical;
 
   const title = `Our Fleet — Motor Yachts, Catamarans, Sailing Yachts & Gulets | ${siteName}`;
   const description =
@@ -22,14 +23,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title,
     description,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/fleet`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title,
       description,

--- a/yalla_london/app/app/glossary/page.tsx
+++ b/yalla_london/app/app/glossary/page.tsx
@@ -1,7 +1,7 @@
 import { headers } from 'next/headers';
 import { Metadata } from 'next';
 import { getDefaultSiteId, getSiteConfig, isYachtSite as checkIsYachtSite } from '@/config/sites';
-import { getBaseUrlForSite } from '@/lib/url-utils';
+import { getBaseUrlForSite, getLocaleAlternates } from '@/lib/url-utils';
 import { GlossaryClientPage } from './glossary-client';
 
 // ─── Glossary Data ─────────────────────────────────────────
@@ -258,10 +258,7 @@ export async function generateMetadata(): Promise<Metadata> {
     title: `Yacht Charter Glossary | ${brandName}`,
     description:
       'A comprehensive bilingual glossary of yacht charter terminology. Learn about yacht types, charter terms, pricing, navigation, and crew roles in English and Arabic.',
-    alternates: {
-      canonical: `${baseUrl}/glossary`,
-      languages: { 'en-GB': `${baseUrl}/glossary`, 'ar-SA': `${baseUrl}/ar/glossary`, 'x-default': `${baseUrl}/glossary` },
-    },
+    alternates: await getLocaleAlternates('/glossary'),
     openGraph: {
       title: `Yacht Charter Glossary | ${brandName}`,
       description: 'Master yacht charter terminology in English and Arabic.',

--- a/yalla_london/app/app/halal-charter/page.tsx
+++ b/yalla_london/app/app/halal-charter/page.tsx
@@ -1,7 +1,7 @@
 import { headers } from 'next/headers';
 import { Metadata } from 'next';
 import { getDefaultSiteId, getSiteConfig } from '@/config/sites';
-import { getBaseUrlForSite } from '@/lib/url-utils';
+import { getBaseUrlForSite, getLocaleAlternates } from '@/lib/url-utils';
 import { HalalCharterClient } from './halal-charter-client';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -16,10 +16,7 @@ export async function generateMetadata(): Promise<Metadata> {
     title: `Halal-Certified Yacht Charters | ${brandName}`,
     description:
       'Luxury halal yacht charters in the Mediterranean. Certified halal catering, prayer-friendly spaces, alcohol-free options, and Arabic-speaking crew. Book your family-friendly charter today.',
-    alternates: {
-      canonical: `${baseUrl}/halal-charter`,
-      languages: { 'en-GB': `${baseUrl}/halal-charter`, 'ar-SA': `${baseUrl}/ar/halal-charter`, 'x-default': `${baseUrl}/halal-charter` },
-    },
+    alternates: await getLocaleAlternates('/halal-charter'),
     openGraph: {
       title: `Halal-Certified Yacht Charters | ${brandName}`,
       description: 'Luxury halal yacht charters with certified catering, prayer spaces, and Arabic-speaking crew.',

--- a/yalla_london/app/app/halal-restaurants-london/page.tsx
+++ b/yalla_london/app/app/halal-restaurants-london/page.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { UtensilsCrossed, MapPin, Star, ArrowRight, Clock } from 'lucide-react'
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from '@/config/sites'
-import { getBaseUrl } from '@/lib/url-utils'
+import { getBaseUrl, getLocaleAlternates } from '@/lib/url-utils'
 import { TriBar, BrandButton, BrandCardLight, SectionLabel, Breadcrumbs } from '@/components/brand-kit'
 import { StructuredData } from '@/components/structured-data'
 
@@ -13,7 +13,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const baseUrl = await getBaseUrl();
   const siteConfig = getSiteConfig(getDefaultSiteId());
   const siteName = siteConfig?.name || 'Yalla London';
-  const canonicalUrl = `${baseUrl}/halal-restaurants-london`;
+  const alternates = await getLocaleAlternates('/halal-restaurants-london');
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `Best Halal Restaurants in London 2026 — Complete Guide | ${siteName}`,
@@ -33,14 +34,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: `Best Halal Restaurants in London | ${siteName}`,
       description: 'The definitive guide to halal dining across London — fine dining, casual eats, and hidden gems.',
     },
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        'en-GB': canonicalUrl,
-        'ar-SA': `${baseUrl}/ar/halal-restaurants-london`,
-        'x-default': canonicalUrl,
-      },
-    },
+    alternates,
     robots: { index: true, follow: true, googleBot: { index: true, follow: true, 'max-image-preview': 'large' as const, 'max-snippet': -1 } },
   }
 }

--- a/yalla_london/app/app/hotels/layout.tsx
+++ b/yalla_london/app/app/hotels/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,19 +13,15 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
   const destination = siteConfig?.destination || "London";
-  const canonicalUrl = await getLocaleAwareCanonical("/hotels");
+  // Locale + site-primary-locale-aware alternates. Works for EN-primary sites
+  // (yalla-london) and AR-primary sites (arabaldives). See lib/url-utils.ts.
+  const alternates = await getLocaleAlternates("/hotels");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `Luxury Hotels in ${destination} | ${siteName}`,
     description: `Discover the finest luxury hotels in ${destination} for Arab visitors. 5-star accommodations with Arabic-speaking staff, halal dining, and prime locations.`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/hotels`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `Luxury Hotels in ${destination} | ${siteName}`,
       description: `Discover the finest luxury hotels in ${destination} for Arab visitors. 5-star accommodations with Arabic-speaking staff, halal dining, and prime locations.`,

--- a/yalla_london/app/app/how-it-works/layout.tsx
+++ b/yalla_london/app/app/how-it-works/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,7 +13,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Zenitha Yachts";
   const siteSlug = siteConfig?.slug || "zenitha-yachts";
   const siteDomain = getSiteDomain(siteId);
-  const canonicalUrl = await getLocaleAwareCanonical("/how-it-works");
+  const alternates = await getLocaleAlternates("/how-it-works");
+  const canonicalUrl = alternates.canonical;
 
   const title = `How It Works | ${siteName}`;
   const description =
@@ -22,14 +23,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title,
     description,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/how-it-works`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title,
       description,

--- a/yalla_london/app/app/information/[section]/page.tsx
+++ b/yalla_london/app/app/information/[section]/page.tsx
@@ -8,6 +8,7 @@ import {
 import { extendedInformationArticles } from "@/data/information-hub-articles-extended";
 import { markdownToHtml } from "@/lib/markdown";
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from "@/config/sites";
+import { getLocaleAlternates } from "@/lib/url-utils";
 import SectionClient from "./SectionClient";
 
 // Combine all information articles
@@ -65,7 +66,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
   }
 
-  const canonicalUrl = `${baseUrl}/information/${slug}`;
+  const alternates = await getLocaleAlternates(`/information/${slug}`);
+  const canonicalUrl = alternates.canonical;
 
   const siteSlug = siteConfig?.slug || "yallalondon";
   const destination = siteConfig?.destination || "London";
@@ -77,14 +79,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     authors: [{ name: `${siteName} Editorial` }],
     creator: siteName,
     publisher: siteName,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/information/${slug}`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `${section.name_en} | ${siteName} Information Hub`,
       description: section.description_en,

--- a/yalla_london/app/app/information/articles/[slug]/page.tsx
+++ b/yalla_london/app/app/information/articles/[slug]/page.tsx
@@ -58,9 +58,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const category = informationCategories.find(
     (c) => c.id === article.category_id,
   );
-  const canonicalUrl = `${baseUrl}/information/articles/${slug}`;
   // Arabic SSR: serve locale-appropriate metadata for /ar/ routes
   const locale = headersList.get("x-locale") || "en";
+  // Locale-aware canonical: Arabic route must self-canonicalize to its /ar/ URL,
+  // otherwise Google treats /ar/information/articles/X as a duplicate of the EN URL.
+  const enUrl = `${baseUrl}/information/articles/${slug}`;
+  const arUrl = `${baseUrl}/ar/information/articles/${slug}`;
+  const canonicalUrl = locale === "ar" ? arUrl : enUrl;
   const metaTitle = locale === "ar"
     ? (article.meta_title_ar || article.title_ar || article.title_en)
     : (article.meta_title_en || article.title_en);
@@ -78,9 +82,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     alternates: {
       canonical: canonicalUrl,
       languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/information/articles/${slug}`,
-        "x-default": canonicalUrl,
+        "en-GB": enUrl,
+        "ar-SA": arUrl,
+        "x-default": enUrl,
       },
     },
     openGraph: {

--- a/yalla_london/app/app/information/articles/[slug]/page.tsx
+++ b/yalla_london/app/app/information/articles/[slug]/page.tsx
@@ -58,12 +58,20 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const category = informationCategories.find(
     (c) => c.id === article.category_id,
   );
-  // Arabic SSR: serve locale-appropriate metadata for /ar/ routes
-  const locale = headersList.get("x-locale") || "en";
-  // Locale-aware canonical: Arabic route must self-canonicalize to its /ar/ URL,
-  // otherwise Google treats /ar/information/articles/X as a duplicate of the EN URL.
-  const enUrl = `${baseUrl}/information/articles/${slug}`;
-  const arUrl = `${baseUrl}/ar/information/articles/${slug}`;
+  // Arabic SSR: serve locale-appropriate metadata.
+  // Effective locale = URL path locale OR the site's primary locale, so
+  // AR-primary sites (arabaldives) render Arabic at root URLs.
+  const pathLocale = headersList.get("x-locale") === "ar" ? "ar" : "en";
+  const sitePrimaryLocale = (headersList.get("x-site-locale") === "ar" ? "ar" : "en") as "en" | "ar";
+  const locale = pathLocale === "ar" ? "ar" : sitePrimaryLocale;
+
+  // Per-site URL structure: AR-primary sites put AR at root.
+  const enUrl = sitePrimaryLocale === "ar"
+    ? `${baseUrl}/en/information/articles/${slug}`
+    : `${baseUrl}/information/articles/${slug}`;
+  const arUrl = sitePrimaryLocale === "ar"
+    ? `${baseUrl}/information/articles/${slug}`
+    : `${baseUrl}/ar/information/articles/${slug}`;
   const canonicalUrl = locale === "ar" ? arUrl : enUrl;
   const metaTitle = locale === "ar"
     ? (article.meta_title_ar || article.title_ar || article.title_en)
@@ -81,11 +89,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     publisher: siteName,
     alternates: {
       canonical: canonicalUrl,
-      languages: {
-        "en-GB": enUrl,
-        "ar-SA": arUrl,
-        "x-default": enUrl,
-      },
+      languages: sitePrimaryLocale === "ar"
+        // AR-primary: skip en-GB — /en/* routes are not implemented yet.
+        ? { "ar-SA": arUrl, "x-default": arUrl }
+        : { "en-GB": enUrl, "ar-SA": arUrl, "x-default": enUrl },
     },
     openGraph: {
       title: metaTitle,

--- a/yalla_london/app/app/information/articles/page.tsx
+++ b/yalla_london/app/app/information/articles/page.tsx
@@ -5,7 +5,7 @@ import {
   informationCategories,
 } from "@/data/information-hub-content";
 import { extendedInformationArticles } from "@/data/information-hub-articles-extended";
-import { getBaseUrl } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from "@/config/sites";
 import ArticleListClient from "./ArticleListClient";
 
@@ -24,7 +24,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
   const destination = siteConfig?.destination || "London";
-  const canonicalUrl = `${baseUrl}/information/articles`;
+  const alternates = await getLocaleAlternates("/information/articles");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `Travel Articles | ${siteName} Information Hub`,
@@ -32,14 +33,7 @@ export async function generateMetadata(): Promise<Metadata> {
       `In-depth travel articles for Arab visitors to ${destination}: trip planning, transport, halal dining, top attractions, and practical insider tips.`,
     keywords:
       `${destination.toLowerCase()} travel articles, arab visitors ${destination.toLowerCase()}, ${destination.toLowerCase()} guide, halal travel ${destination.toLowerCase()}, information hub`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/information/articles`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `Travel Articles | ${siteName} Information Hub`,
       description:

--- a/yalla_london/app/app/information/page.tsx
+++ b/yalla_london/app/app/information/page.tsx
@@ -6,7 +6,7 @@ import {
   informationCategories,
 } from "@/data/information-hub-content";
 import { extendedInformationArticles } from "@/data/information-hub-articles-extended";
-import { getBaseUrl } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from "@/config/sites";
 import InformationHubClient from "./InformationHubClient";
 
@@ -25,7 +25,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
   const destination = siteConfig?.destination || "London";
-  const canonicalUrl = `${baseUrl}/information`;
+  const alternates = await getLocaleAlternates("/information");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `${destination} Travel Guide | ${siteName} Info Hub`,
@@ -33,14 +34,7 @@ export async function generateMetadata(): Promise<Metadata> {
       `Plan your ${destination} trip with expert tips: halal dining, transport guides, neighbourhood walks, family activities, and practical advice for Arab visitors.`,
     keywords:
       `${destination.toLowerCase()} travel guide, arab visitors ${destination.toLowerCase()}, ${destination.toLowerCase()} information, halal ${destination.toLowerCase()} guide, ${destination.toLowerCase()} trip planner`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/information`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `Information Hub | ${siteName} \u2013 Your Complete ${destination} Travel Guide`,
       description:

--- a/yalla_london/app/app/inquiry/layout.tsx
+++ b/yalla_london/app/app/inquiry/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import {
   getDefaultSiteId,
   getSiteConfig,
@@ -21,21 +21,17 @@ export async function generateMetadata(): Promise<Metadata> {
   const description =
     "Request a personalised yacht charter quote. Tell us about your dream Mediterranean sailing holiday and our experts will curate the perfect voyage within 24 hours.";
 
+  const alternates = await getLocaleAlternates("/inquiry");
+  const canonicalUrl = alternates.canonical;
+
   return {
     title,
     description,
-    alternates: {
-      canonical: await getLocaleAwareCanonical("/inquiry"),
-      languages: {
-        "en-GB": await getLocaleAwareCanonical("/inquiry"),
-        "ar-SA": `${baseUrl}/ar/inquiry`,
-        "x-default": await getLocaleAwareCanonical("/inquiry"),
-      },
-    },
+    alternates,
     openGraph: {
       title,
       description,
-      url: await getLocaleAwareCanonical("/inquiry"),
+      url: canonicalUrl,
       siteName,
       type: "website",
       locale: "en_GB",

--- a/yalla_london/app/app/itineraries/[slug]/page.tsx
+++ b/yalla_london/app/app/itineraries/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { headers } from "next/headers";
 import Link from "next/link";
 import Image from "next/image";
 import { notFound } from "next/navigation";
-import { getBaseUrl } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDescription } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 import {
@@ -106,19 +106,13 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     console.warn("[itinerary-detail] metadata DB query failed:", e);
   }
 
-  const canonicalUrl = `${baseUrl}/itineraries/${slug}`;
+  const alternates = await getLocaleAlternates(`/itineraries/${slug}`);
+  const canonicalUrl = alternates.canonical;
 
   return {
     title,
     description,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/itineraries/${slug}`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title,
       description,

--- a/yalla_london/app/app/itineraries/layout.tsx
+++ b/yalla_london/app/app/itineraries/layout.tsx
@@ -15,6 +15,20 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteDomain = getSiteDomain(siteId);
   const canonicalUrl = await getLocaleAwareCanonical("/itineraries");
 
+  // Soft-404 prevention: if no itineraries exist for this site, the page
+  // renders only an empty-state CTA. Tell Google not to index until we
+  // have substantive content — otherwise GSC flags as "Soft 404".
+  let hasContent = false;
+  try {
+    const { prisma } = await import("@/lib/db");
+    const count = await prisma.charterItinerary.count({
+      where: { siteId, status: "active" },
+    });
+    hasContent = count > 0;
+  } catch (err) {
+    console.warn("[itineraries/layout] count query failed:", err instanceof Error ? err.message : String(err));
+  }
+
   return {
     title: `Sailing Itineraries | ${siteName}`,
     description:
@@ -52,10 +66,10 @@ export async function generateMetadata(): Promise<Metadata> {
         "Curated Mediterranean sailing routes with day-by-day breakdowns.",
     },
     robots: {
-      index: true,
+      index: hasContent,
       follow: true,
       googleBot: {
-        index: true,
+        index: hasContent,
         follow: true,
         "max-video-preview": -1,
         "max-image-preview": "large",

--- a/yalla_london/app/app/itineraries/layout.tsx
+++ b/yalla_london/app/app/itineraries/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,7 +13,9 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Zenitha Yachts";
   const siteSlug = siteConfig?.slug || "zenitha-yachts";
   const siteDomain = getSiteDomain(siteId);
-  const canonicalUrl = await getLocaleAwareCanonical("/itineraries");
+  // Locale + site-primary-locale-aware alternates.
+  const alternates = await getLocaleAlternates("/itineraries");
+  const canonicalUrl = alternates.canonical;
 
   // Soft-404 prevention: if no itineraries exist for this site, the page
   // renders only an empty-state CTA. Tell Google not to index until we
@@ -33,14 +35,7 @@ export async function generateMetadata(): Promise<Metadata> {
     title: `Sailing Itineraries | ${siteName}`,
     description:
       "Curated Mediterranean sailing routes with day-by-day breakdowns. Explore Greek Islands, Croatian Coast, Turkish Riviera, and more with expert-planned yacht charter itineraries.",
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/itineraries`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `Sailing Itineraries | ${siteName}`,
       description:

--- a/yalla_london/app/app/journal/[slug]/page.tsx
+++ b/yalla_london/app/app/journal/[slug]/page.tsx
@@ -11,7 +11,7 @@ import {
   ArrowRight,
   Tag,
 } from "lucide-react";
-import { getBaseUrl } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from "@/config/sites";
 import { sanitizeHtml } from "@/lib/html-sanitizer";
 import { StructuredData } from "@/components/structured-data";
@@ -32,7 +32,8 @@ export async function generateMetadata({
   const siteConfig = getSiteConfig(siteId);
   const siteName = siteConfig?.name || "Zenitha Yachts";
   const siteDomain = getSiteDomain(siteId);
-  const canonicalUrl = `${baseUrl}/journal/${slug}`;
+  const alternates = await getLocaleAlternates(`/journal/${slug}`);
+  const canonicalUrl = alternates.canonical;
 
   /* Try loading article title from DB */
   let title = `Charter Guide | ${siteName}`;
@@ -64,14 +65,7 @@ export async function generateMetadata({
   return {
     title,
     description,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/journal/${slug}`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title,
       description,

--- a/yalla_london/app/app/journal/layout.tsx
+++ b/yalla_london/app/app/journal/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,7 +13,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Zenitha Yachts";
   const siteSlug = siteConfig?.slug || "zenitha-yachts";
   const siteDomain = getSiteDomain(siteId);
-  const canonicalUrl = await getLocaleAwareCanonical("/journal");
+  const alternates = await getLocaleAlternates("/journal");
+  const canonicalUrl = alternates.canonical;
 
   const title = `The Zenitha Journal — Charter Guides, Sailing Tips & Destination Stories | ${siteName}`;
   const description =
@@ -22,14 +23,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title,
     description,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/journal`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title,
       description,

--- a/yalla_london/app/app/layout.tsx
+++ b/yalla_london/app/app/layout.tsx
@@ -30,7 +30,7 @@ import { WebVitalsReporter } from "@/components/web-vitals-reporter";
 import { brandConfig } from "@/config/brand-config";
 // HreflangTags component removed — hreflang is handled by generateMetadata().alternates.languages
 // in each layout/page file. The component was causing duplicate hreflang tags on every page.
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDescription, getSiteTagline, getSiteNameAr, isYachtSite as checkIsYachtSite } from "@/config/sites";
 import type { Language } from "@/lib/types";
 
@@ -155,14 +155,7 @@ export async function generateMetadata(): Promise<Metadata> {
         "max-snippet": -1,
       },
     },
-    alternates: {
-      canonical: await getLocaleAwareCanonical(),
-      languages: {
-        "en-GB": baseUrl,
-        "ar-SA": `${baseUrl}/ar`,
-        "x-default": baseUrl,
-      },
-    },
+    alternates: await getLocaleAlternates(""),
   };
 }
 

--- a/yalla_london/app/app/london-by-foot/[slug]/page.tsx
+++ b/yalla_london/app/app/london-by-foot/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { notFound } from 'next/navigation'
 import { MapPin, Clock, ArrowLeft, ArrowRight, Download, Footprints, Compass, Camera, Coffee } from 'lucide-react'
 import { walks } from '../walks-data'
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from '@/config/sites'
-import { getBaseUrl } from '@/lib/url-utils'
+import { getBaseUrl, getLocaleAlternates } from '@/lib/url-utils'
 
 // ISR: Revalidate walk detail pages every hour
 export const revalidate = 3600;
@@ -27,7 +27,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const siteConfig = getSiteConfig(getDefaultSiteId());
   const siteName = siteConfig?.name || 'Yalla London';
   const destination = siteConfig?.destination || 'London';
-  const canonicalUrl = `${baseUrl}/london-by-foot/${slug}`;
+  const alternates = await getLocaleAlternates(`/london-by-foot/${slug}`);
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `${walk.title} — ${destination} Walking Guide | ${siteName}`,
@@ -49,14 +50,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title: `${walk.title} | ${siteName}`,
       description: walk.subtitle,
     },
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        'en-GB': canonicalUrl,
-        'ar-SA': `${baseUrl}/ar/london-by-foot/${slug}`,
-        'x-default': canonicalUrl,
-      },
-    },
+    alternates,
     robots: {
       index: true,
       follow: true,

--- a/yalla_london/app/app/london-by-foot/page.tsx
+++ b/yalla_london/app/app/london-by-foot/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { MapPin, Clock, ArrowRight, Footprints, Download } from 'lucide-react'
 import { walks } from './walks-data'
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from '@/config/sites'
-import { getBaseUrl } from '@/lib/url-utils'
+import { getBaseUrl, getLocaleAlternates } from '@/lib/url-utils'
 import { TriBar, BrandButton, BrandTag, BrandCardLight, SectionLabel, WatermarkStamp, Breadcrumbs } from '@/components/brand-kit'
 
 // ISR: Revalidate walking guides every hour
@@ -15,7 +15,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteConfig = getSiteConfig(getDefaultSiteId());
   const siteName = siteConfig?.name || 'Yalla London';
   const destination = siteConfig?.destination || 'London';
-  const canonicalUrl = `${baseUrl}/london-by-foot`;
+  const alternates = await getLocaleAlternates('/london-by-foot');
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `${destination} by Foot — Self-Guided Walking Tours | ${siteName}`,
@@ -36,14 +37,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: `${destination} by Foot | ${siteName}`,
       description: `5 curated walking routes through ${destination} with maps, photos, and insider tips`,
     },
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        'en-GB': canonicalUrl,
-        'ar-SA': `${baseUrl}/ar/london-by-foot`,
-        'x-default': canonicalUrl,
-      },
-    },
+    alternates,
     robots: {
       index: true,
       follow: true,

--- a/yalla_london/app/app/london-with-kids/page.tsx
+++ b/yalla_london/app/app/london-with-kids/page.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Baby, MapPin, Star, ArrowRight, Ticket, TreePine, Castle } from 'lucide-react'
 import { getDefaultSiteId, getSiteConfig } from '@/config/sites'
-import { getBaseUrl } from '@/lib/url-utils'
+import { getBaseUrl, getLocaleAlternates } from '@/lib/url-utils'
 import { TriBar, BrandButton, BrandCardLight, SectionLabel, Breadcrumbs } from '@/components/brand-kit'
 import { StructuredData } from '@/components/structured-data'
 
@@ -13,7 +13,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const baseUrl = await getBaseUrl();
   const siteConfig = getSiteConfig(getDefaultSiteId());
   const siteName = siteConfig?.name || 'Yalla London';
-  const canonicalUrl = `${baseUrl}/london-with-kids`;
+  const alternates = await getLocaleAlternates('/london-with-kids');
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `London with Kids 2026 — Family Activities & Attractions Guide | ${siteName}`,
@@ -33,14 +34,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: `London with Kids | ${siteName}`,
       description: 'The complete family guide to London — attractions, restaurants, parks, and practical tips.',
     },
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        'en-GB': canonicalUrl,
-        'ar-SA': `${baseUrl}/ar/london-with-kids`,
-        'x-default': canonicalUrl,
-      },
-    },
+    alternates,
     robots: { index: true, follow: true, googleBot: { index: true, follow: true, 'max-image-preview': 'large' as const, 'max-snippet': -1 } },
   }
 }

--- a/yalla_london/app/app/luxury-hotels-london/page.tsx
+++ b/yalla_london/app/app/luxury-hotels-london/page.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Hotel, MapPin, Star, ArrowRight, Wifi, Dumbbell, UtensilsCrossed, ExternalLink } from 'lucide-react'
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from '@/config/sites'
-import { getBaseUrl } from '@/lib/url-utils'
+import { getBaseUrl, getLocaleAlternates } from '@/lib/url-utils'
 import { TriBar, BrandButton, BrandCardLight, SectionLabel, Breadcrumbs } from '@/components/brand-kit'
 import { StructuredData } from '@/components/structured-data'
 
@@ -13,7 +13,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const baseUrl = await getBaseUrl();
   const siteConfig = getSiteConfig(getDefaultSiteId());
   const siteName = siteConfig?.name || 'Yalla London';
-  const canonicalUrl = `${baseUrl}/luxury-hotels-london`;
+  const alternates = await getLocaleAlternates('/luxury-hotels-london');
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `Best Luxury Hotels in London 2026 — 5-Star Guide | ${siteName}`,
@@ -33,14 +34,7 @@ export async function generateMetadata(): Promise<Metadata> {
       title: `Best Luxury Hotels in London | ${siteName}`,
       description: 'The definitive guide to 5-star hotels across London — with halal-friendly and family options.',
     },
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        'en-GB': canonicalUrl,
-        'ar-SA': `${baseUrl}/ar/luxury-hotels-london`,
-        'x-default': canonicalUrl,
-      },
-    },
+    alternates,
     robots: { index: true, follow: true, googleBot: { index: true, follow: true, 'max-image-preview': 'large' as const, 'max-snippet': -1 } },
   }
 }

--- a/yalla_london/app/app/news/[slug]/page.tsx
+++ b/yalla_london/app/app/news/[slug]/page.tsx
@@ -260,9 +260,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
   }
 
-  const canonicalUrl = `${baseUrl}/news/${slug}`;
   // Arabic SSR: serve locale-appropriate metadata for /ar/ routes
   const locale = headersList.get("x-locale") || "en";
+  // Locale-aware canonical: Arabic route must self-canonicalize to its /ar/ URL,
+  // otherwise Google treats /ar/news/X as a duplicate of /news/X and deindexes it.
+  const enUrl = `${baseUrl}/news/${slug}`;
+  const arUrl = `${baseUrl}/ar/news/${slug}`;
+  const canonicalUrl = locale === "ar" ? arUrl : enUrl;
   const title = locale === "ar"
     ? (item.meta_title_ar || `${item.headline_ar} | ${siteName}`)
     : (item.meta_title_en || `${item.headline_en} | ${siteName}`);
@@ -280,9 +284,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     alternates: {
       canonical: canonicalUrl,
       languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/news/${slug}`,
-        "x-default": canonicalUrl,
+        "en-GB": enUrl,
+        "ar-SA": arUrl,
+        "x-default": enUrl,
       },
     },
     openGraph: {
@@ -290,8 +294,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       description,
       url: canonicalUrl,
       siteName,
-      locale: "en_GB",
-      alternateLocale: "ar_SA",
+      locale: locale === "ar" ? "ar_SA" : "en_GB",
+      alternateLocale: locale === "ar" ? "en_GB" : "ar_SA",
       type: "article",
       publishedTime: item.published_at,
       authors: [item.source_name],

--- a/yalla_london/app/app/news/[slug]/page.tsx
+++ b/yalla_london/app/app/news/[slug]/page.tsx
@@ -260,12 +260,24 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
   }
 
-  // Arabic SSR: serve locale-appropriate metadata for /ar/ routes
-  const locale = headersList.get("x-locale") || "en";
-  // Locale-aware canonical: Arabic route must self-canonicalize to its /ar/ URL,
-  // otherwise Google treats /ar/news/X as a duplicate of /news/X and deindexes it.
-  const enUrl = `${baseUrl}/news/${slug}`;
-  const arUrl = `${baseUrl}/ar/news/${slug}`;
+  // Arabic SSR: serve locale-appropriate metadata.
+  // Effective locale combines URL path locale (/ar/* → ar) with the SITE's
+  // primary locale — so AR-primary sites (arabaldives) render Arabic at
+  // root URLs even when pathLocale is "en".
+  const pathLocale = headersList.get("x-locale") === "ar" ? "ar" : "en";
+  const sitePrimaryLocale = (headersList.get("x-site-locale") === "ar" ? "ar" : "en") as "en" | "ar";
+  const locale = pathLocale === "ar" ? "ar" : sitePrimaryLocale;
+
+  // Per-site URL structure: EN-primary sites put AR at /ar/*,
+  // AR-primary sites put AR at root. (EN fallback on AR-primary sites
+  // would live at /en/* — not implemented today, so we omit en-GB hreflang
+  // in alternates below when primary is AR.)
+  const enUrl = sitePrimaryLocale === "ar"
+    ? `${baseUrl}/en/news/${slug}`
+    : `${baseUrl}/news/${slug}`;
+  const arUrl = sitePrimaryLocale === "ar"
+    ? `${baseUrl}/news/${slug}`
+    : `${baseUrl}/ar/news/${slug}`;
   const canonicalUrl = locale === "ar" ? arUrl : enUrl;
   const title = locale === "ar"
     ? (item.meta_title_ar || `${item.headline_ar} | ${siteName}`)
@@ -283,11 +295,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     publisher: siteName,
     alternates: {
       canonical: canonicalUrl,
-      languages: {
-        "en-GB": enUrl,
-        "ar-SA": arUrl,
-        "x-default": enUrl,
-      },
+      languages: sitePrimaryLocale === "ar"
+        // AR-primary: omit en-GB — /en/news/X does not yet exist and promising
+        // it to Google would produce 404s.
+        ? { "ar-SA": arUrl, "x-default": arUrl }
+        : { "en-GB": enUrl, "ar-SA": arUrl, "x-default": enUrl },
     },
     openGraph: {
       title,

--- a/yalla_london/app/app/news/page.tsx
+++ b/yalla_london/app/app/news/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 import { headers } from "next/headers";
 import { prisma } from "@/lib/db";
-import { getBaseUrl } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig, getSiteDomain } from "@/config/sites";
 import NewsListClient from "./NewsListClient";
 
@@ -17,7 +17,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
   const destination = siteConfig?.destination || "London";
-  const canonicalUrl = `${baseUrl}/news`;
+  const alternates = await getLocaleAlternates("/news");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `${destination} Today — News & Updates | ${siteName}`,
@@ -25,14 +26,7 @@ export async function generateMetadata(): Promise<Metadata> {
       `Latest ${destination} news, transport updates, events, and travel tips curated for Arab visitors. Stay informed with your daily briefing.`,
     keywords:
       `${destination.toLowerCase()} news, ${destination.toLowerCase()} today, ${destination.toLowerCase()} transport updates, ${destination.toLowerCase()} events, arab visitors`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/news`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `${destination} Today — News & Updates | ${siteName}`,
       description:

--- a/yalla_london/app/app/page.tsx
+++ b/yalla_london/app/app/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import {
   getDefaultSiteId,
   getSiteConfig,
@@ -35,6 +35,9 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteSlug = siteConfig?.slug || "yalla-london";
   const siteName = siteConfig?.name || "Yalla London";
   const siteNameAr = getSiteNameAr(siteId);
+  // Root-path alternates — primary-locale-aware. Emits en-GB+ar-SA on
+  // EN-primary sites, ar-SA only on AR-primary sites (arabaldives).
+  const rootAlternates = await getLocaleAlternates("");
 
   if (isParentBrandSite(siteId)) {
     const title = "Zenitha.Luxury — Luxury Travel Brands & Destination Expertise";
@@ -72,14 +75,7 @@ export async function generateMetadata(): Promise<Metadata> {
     return {
       title,
       description,
-      alternates: {
-        canonical: baseUrl,
-        languages: {
-          "en-GB": baseUrl,
-          "ar-SA": `${baseUrl}/ar`,
-          "x-default": baseUrl,
-        },
-      },
+      alternates: rootAlternates,
       openGraph: {
         title,
         description,
@@ -124,14 +120,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: `${siteName} — ${siteTagline} | ${siteNameAr}`,
     description: siteDescription,
-    alternates: {
-      canonical: baseUrl,
-      languages: {
-        "en-GB": baseUrl,
-        "ar-SA": `${baseUrl}/ar`,
-        "x-default": baseUrl,
-      },
-    },
+    alternates: rootAlternates,
     openGraph: {
       title: `${siteName} — ${siteTagline}`,
       description: siteDescription,

--- a/yalla_london/app/app/privacy/layout.tsx
+++ b/yalla_london/app/app/privacy/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,19 +13,13 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
   const destination = siteConfig?.destination || "London";
-  const canonicalUrl = await getLocaleAwareCanonical("/privacy");
+  const alternates = await getLocaleAlternates("/privacy");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `Privacy Policy — Data Protection | ${siteName}`,
     description: `How ${siteName} collects, uses, and protects your personal data under UK GDPR. Read our full privacy policy covering cookies, analytics, and your rights.`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/privacy`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `Privacy Policy | ${siteName}`,
       description: `How ${siteName} collects, uses, and protects your personal data under UK GDPR. Read our full privacy policy covering cookies, analytics, and your rights.`,

--- a/yalla_london/app/app/recommendations/layout.tsx
+++ b/yalla_london/app/app/recommendations/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,19 +13,14 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
   const destination = siteConfig?.destination || "London";
-  const canonicalUrl = await getLocaleAwareCanonical("/recommendations");
+  // Locale + site-primary-locale-aware alternates.
+  const alternates = await getLocaleAlternates("/recommendations");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `Curated ${destination} Recommendations | ${siteName}`,
     description: `Our hand-picked ${destination} recommendations — luxury hotels, fine dining restaurants, and must-visit attractions curated for discerning Arab travelers.`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/recommendations`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `Curated ${destination} Recommendations | ${siteName}`,
       description: `Our hand-picked ${destination} recommendations — luxury hotels, fine dining restaurants, and must-visit attractions curated for discerning Arab travelers.`,

--- a/yalla_london/app/app/shop/layout.tsx
+++ b/yalla_london/app/app/shop/layout.tsx
@@ -4,6 +4,7 @@ import { headers } from "next/headers";
 import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
+import { buildDigitalProductSchema } from "@/lib/seo/product-schema";
 
 export async function generateMetadata(): Promise<Metadata> {
   const baseUrl = await getBaseUrl();
@@ -73,24 +74,25 @@ export default async function Layout({ children }: { children: React.ReactNode }
   const destination = siteConfig?.destination || "London";
   const baseUrl = await getBaseUrl();
 
-  // Product JSON-LD for each guide
-  const productSchemas = SHOP_PRODUCTS.map((p) => ({
-    "@context": "https://schema.org",
-    "@type": "Product",
-    name: p.name,
-    description: p.description,
-    image: p.image,
-    brand: { "@type": "Organization", name: siteName },
-    offers: {
-      "@type": "Offer",
-      price: p.price,
-      priceCurrency: "GBP",
-      availability: "https://schema.org/InStock",
-      url: `${baseUrl}/shop#${p.slug}`,
-      seller: { "@type": "Organization", name: siteName },
-    },
-    category: "Travel Guide",
-  }));
+  // Product JSON-LD for each guide — uses shared helper so brand type, return
+  // policy, and shipping details stay aligned with Google's Merchant Listing spec.
+  const productSchemas = SHOP_PRODUCTS.map((p) =>
+    buildDigitalProductSchema({
+      name: p.name,
+      description: p.description,
+      image: p.image,
+      brandName: siteName,
+      category: "Travel Guide",
+      offer: {
+        price: p.price,
+        priceCurrency: "GBP",
+        url: `${baseUrl}/shop#${p.slug}`,
+        sellerName: siteName,
+        country: "GB",
+        returnDays: 14,
+      },
+    })
+  );
 
   return (
     <>

--- a/yalla_london/app/app/shop/layout.tsx
+++ b/yalla_london/app/app/shop/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 import { buildDigitalProductSchema } from "@/lib/seo/product-schema";
@@ -14,19 +14,13 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
   const destination = siteConfig?.destination || "London";
-  const canonicalUrl = await getLocaleAwareCanonical("/shop");
+  const alternates = await getLocaleAlternates("/shop");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `${destination} Travel Guides & Digital Products | ${siteName} Shop`,
     description: `Download premium ${destination} travel guides, maps, and planning tools. Expert-curated content for Arab visitors — instant digital delivery.`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/shop`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `${destination} Travel Guides & Digital Products | ${siteName} Shop`,
       description: `Download premium ${destination} travel guides, maps, and planning tools. Expert-curated content for Arab visitors — instant digital delivery.`,

--- a/yalla_london/app/app/sitemap.ts
+++ b/yalla_london/app/app/sitemap.ts
@@ -72,6 +72,22 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
  */
 async function buildFallbackSitemap(baseUrl: string, siteId: string): Promise<MetadataRoute.Sitemap> {
   const now = new Date().toISOString();
+  // Primary locale determines URL structure (see lib/sitemap-cache.ts for
+  // full explanation). Mirror the same logic in the fallback so cache-miss
+  // responses match cache-hit responses.
+  const siteConfig = (await import("@/config/sites")).getSiteConfig(siteId);
+  const primaryLocale: "en" | "ar" = siteConfig?.locale === "ar" ? "ar" : "en";
+  function hreflang(path: string) {
+    if (primaryLocale === "ar") {
+      const arUrl = path ? `${baseUrl}${path}` : baseUrl;
+      return { languages: { "ar-SA": arUrl, "x-default": arUrl } };
+    }
+    const enUrl = path ? `${baseUrl}${path}` : baseUrl;
+    const arUrl = path ? `${baseUrl}/ar${path}` : `${baseUrl}/ar`;
+    return {
+      languages: { "en-GB": enUrl, "ar-SA": arUrl, "x-default": enUrl },
+    };
+  }
   const pages: { path: string; priority: number; changeFrequency: "daily" | "weekly" | "monthly" | "yearly" }[] = [
     // Homepage — changes frequently with new content
     { path: "", priority: 1, changeFrequency: "daily" },
@@ -118,13 +134,7 @@ async function buildFallbackSitemap(baseUrl: string, siteId: string): Promise<Me
     lastModified: now,
     changeFrequency,
     priority,
-    alternates: {
-      languages: {
-        "en-GB": path ? `${baseUrl}${path}` : baseUrl,
-        "ar-SA": path ? `${baseUrl}/ar${path}` : `${baseUrl}/ar`,
-        "x-default": path ? `${baseUrl}${path}` : baseUrl,
-      },
-    },
+    alternates: hreflang(path),
   }));
 
   // Live query for published blog posts — single fast query, no cache needed.
@@ -149,13 +159,7 @@ async function buildFallbackSitemap(baseUrl: string, siteId: string): Promise<Me
         lastModified: post.updated_at?.toISOString() || now,
         changeFrequency: "weekly" as const,
         priority: 0.8,
-        alternates: {
-          languages: {
-            "en-GB": `${baseUrl}/blog/${post.slug}`,
-            "ar-SA": `${baseUrl}/ar/blog/${post.slug}`,
-            "x-default": `${baseUrl}/blog/${post.slug}`,
-          },
-        },
+        alternates: hreflang(`/blog/${post.slug}`),
       });
     }
   } catch (err) {

--- a/yalla_london/app/app/sitemap.ts
+++ b/yalla_london/app/app/sitemap.ts
@@ -83,7 +83,9 @@ async function buildFallbackSitemap(baseUrl: string, siteId: string): Promise<Me
     { path: "/events", priority: 0.8, changeFrequency: "weekly" },
     { path: "/news", priority: 0.8, changeFrequency: "daily" },
     { path: "/halal-restaurants-london", priority: 0.9, changeFrequency: "weekly" },
-    { path: "/luxury-hotels-london", priority: 0.9, changeFrequency: "weekly" },
+    // Intentionally NOT listing /luxury-hotels-london — middleware 301-redirects
+    // it to /hotels (PAGE_REDIRECTS). Listing a redirected URL in the sitemap
+    // generates GSC "Page redirects" warnings and wastes crawl budget.
     { path: "/london-with-kids", priority: 0.9, changeFrequency: "weekly" },
     { path: "/london-by-foot", priority: 0.9, changeFrequency: "weekly" },
     // Structured data pages — high SEO value
@@ -91,8 +93,9 @@ async function buildFallbackSitemap(baseUrl: string, siteId: string): Promise<Me
     { path: "/glossary", priority: 0.8, changeFrequency: "monthly" },
     { path: "/halal-charter", priority: 0.9, changeFrequency: "monthly" },
     // Navigation & discovery pages
-    { path: "/destinations", priority: 0.8, changeFrequency: "weekly" },
-    { path: "/itineraries", priority: 0.8, changeFrequency: "weekly" },
+    // /destinations + /itineraries are yacht-charter features (Zenitha Yachts only).
+    // On blog sites (yalla-london) they render an empty "Coming Soon" state → soft 404.
+    // The yacht-site sitemap in lib/sitemap-cache.ts includes them for zenitha-yachts-med.
     { path: "/journal", priority: 0.7, changeFrequency: "weekly" },
     { path: "/information", priority: 0.7, changeFrequency: "weekly" },
     { path: "/shop", priority: 0.7, changeFrequency: "weekly" },
@@ -124,9 +127,15 @@ async function buildFallbackSitemap(baseUrl: string, siteId: string): Promise<Me
     },
   }));
 
-  // Live query for published blog posts — single fast query, no cache needed
+  // Live query for published blog posts — single fast query, no cache needed.
+  // Filter out slugs that are in BLOG_REDIRECTS: listing a redirected URL in
+  // the sitemap triggers GSC "Page redirects" warnings.
   try {
     const { prisma } = await import("@/lib/db");
+    const { BLOG_REDIRECTS } = await import("@/lib/seo/redirect-map");
+    const redirectedSlugs = new Set<string>(
+      Object.keys(BLOG_REDIRECTS).map((path) => path.replace(/^\/blog\//, ""))
+    );
     const posts = await prisma.blogPost.findMany({
       where: { published: true, deletedAt: null, siteId },
       select: { slug: true, updated_at: true },
@@ -134,6 +143,7 @@ async function buildFallbackSitemap(baseUrl: string, siteId: string): Promise<Me
       take: 5000,
     });
     for (const post of posts) {
+      if (redirectedSlugs.has(post.slug)) continue;
       entries.push({
         url: `${baseUrl}/blog/${post.slug}`,
         lastModified: post.updated_at?.toISOString() || now,

--- a/yalla_london/app/app/team/[slug]/page.tsx
+++ b/yalla_london/app/app/team/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { prisma } from "@/lib/db";
 import { getDefaultSiteId, getSiteDomain } from "@/config/sites";
+import { getLocaleAlternates } from "@/lib/url-utils";
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -22,16 +23,12 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const title = `${member.name_en} — ${member.title_en}`;
   const description = member.bio_en.slice(0, 155);
 
+  const alternates = await getLocaleAlternates(`/team/${slug}`);
+
   return {
     title,
     description,
-    alternates: {
-      canonical: `${baseUrl}/team/${slug}`,
-      languages: {
-        "en-GB": `${baseUrl}/team/${slug}`,
-        "x-default": `${baseUrl}/team/${slug}`,
-      },
-    },
+    alternates,
     openGraph: {
       title,
       description,

--- a/yalla_london/app/app/terms/layout.tsx
+++ b/yalla_london/app/app/terms/layout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl, getLocaleAwareCanonical } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import { getDefaultSiteId, getSiteConfig } from "@/config/sites";
 import { StructuredData } from "@/components/structured-data";
 
@@ -13,19 +13,13 @@ export async function generateMetadata(): Promise<Metadata> {
   const siteName = siteConfig?.name || "Yalla London";
   const siteSlug = siteConfig?.slug || "yallalondon";
   const destination = siteConfig?.destination || "London";
-  const canonicalUrl = await getLocaleAwareCanonical("/terms");
+  const alternates = await getLocaleAlternates("/terms");
+  const canonicalUrl = alternates.canonical;
 
   return {
     title: `Terms of Use — Legal Information | ${siteName}`,
     description: `${siteName} terms and conditions covering website content usage, affiliate relationships, digital product purchases, and user responsibilities.`,
-    alternates: {
-      canonical: canonicalUrl,
-      languages: {
-        "en-GB": canonicalUrl,
-        "ar-SA": `${baseUrl}/ar/terms`,
-        "x-default": canonicalUrl,
-      },
-    },
+    alternates,
     openGraph: {
       title: `Terms of Use | ${siteName}`,
       description: `${siteName} terms and conditions covering website content usage, affiliate relationships, digital product purchases, and user responsibilities.`,

--- a/yalla_london/app/app/tools/seo-audit/layout.tsx
+++ b/yalla_london/app/app/tools/seo-audit/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { getBaseUrl } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 
 export async function generateMetadata(): Promise<Metadata> {
   const baseUrl = await getBaseUrl();
@@ -22,14 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
       description:
         "Get a comprehensive SEO score for any webpage in seconds. No signup required.",
     },
-    alternates: {
-      canonical: `${baseUrl}/tools/seo-audit`,
-      languages: {
-        "en-GB": `${baseUrl}/tools/seo-audit`,
-        "ar-SA": `${baseUrl}/ar/tools/seo-audit`,
-        "x-default": `${baseUrl}/tools/seo-audit`,
-      },
-    },
+    alternates: await getLocaleAlternates("/tools/seo-audit"),
     robots: {
       index: true,
       follow: true,

--- a/yalla_london/app/app/yachts/[slug]/page.tsx
+++ b/yalla_london/app/app/yachts/[slug]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { Metadata } from "next";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
-import { getBaseUrl } from "@/lib/url-utils";
+import { getBaseUrl, getLocaleAlternates } from "@/lib/url-utils";
 import {
   getDefaultSiteId,
   getSiteConfig,
@@ -275,17 +275,12 @@ export async function generateMetadata({
     yacht.description_en?.substring(0, 155) ||
     `Charter the ${yacht.name}, a ${yacht.length}m ${yachtType.toLowerCase()} with ${yacht.cabins} cabins. ${yacht.halalCateringAvailable ? "Halal catering available. " : ""}Book your Mediterranean charter today.`;
 
+  const alternates = await getLocaleAlternates(`/yachts/${slug}`);
+
   return {
     title,
     description,
-    alternates: {
-      canonical: `${baseUrl}/yachts/${slug}`,
-      languages: {
-        "en-GB": `${baseUrl}/yachts/${slug}`,
-        "ar-SA": `${baseUrl}/ar/yachts/${slug}`,
-        "x-default": `${baseUrl}/yachts/${slug}`,
-      },
-    },
+    alternates,
     openGraph: {
       title,
       description,

--- a/yalla_london/app/app/yachts/compare/page.tsx
+++ b/yalla_london/app/app/yachts/compare/page.tsx
@@ -1,22 +1,15 @@
 import { Metadata } from "next";
 import { headers } from "next/headers";
-import { getBaseUrl } from "@/lib/url-utils";
+import { getLocaleAlternates } from "@/lib/url-utils";
 import CompareClient from "./compare-client";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const baseUrl = await getBaseUrl();
+  const alternates = await getLocaleAlternates("/yachts/compare");
   return {
     title: "Compare Yachts | Zenitha Yachts",
     description:
       "Compare charter yachts side-by-side. View specifications, pricing, amenities, and features to find your perfect Mediterranean yacht charter.",
-    alternates: {
-      canonical: `${baseUrl}/yachts/compare`,
-      languages: {
-        "en-GB": `${baseUrl}/yachts/compare`,
-        "ar-SA": `${baseUrl}/ar/yachts/compare`,
-        "x-default": `${baseUrl}/yachts/compare`,
-      },
-    },
+    alternates,
     robots: { index: true, follow: true },
   };
 }

--- a/yalla_london/app/app/yachts/page.tsx
+++ b/yalla_london/app/app/yachts/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import { Metadata } from 'next';
 import { headers } from 'next/headers';
-import { getBaseUrl } from '@/lib/url-utils';
+import { getBaseUrl, getLocaleAlternates } from '@/lib/url-utils';
 import { getDefaultSiteId, getSiteConfig } from '@/config/sites';
 import { YachtSearchClient } from './yacht-search-client';
 import { WhatsAppButton } from '@/components/zenitha/whatsapp-button';
@@ -16,14 +16,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: `Browse Luxury Yachts for Charter — Sailing, Catamarans, Motor Yachts | ${siteName}`,
     description: 'Explore 200+ handpicked yachts. Filter by destination, type, guests, budget, and halal catering. Mediterranean, Arabian Gulf, and beyond.',
-    alternates: {
-      canonical: `${baseUrl}/yachts`,
-      languages: {
-        'en-GB': `${baseUrl}/yachts`,
-        'ar-SA': `${baseUrl}/ar/yachts`,
-        'x-default': `${baseUrl}/yachts`,
-      },
-    },
+    alternates: await getLocaleAlternates('/yachts'),
     openGraph: {
       title: `Browse Luxury Yachts for Charter | ${siteName}`,
       description: 'Explore 200+ handpicked yachts. Filter by destination, type, guests, budget, and halal catering.',

--- a/yalla_london/app/components/structured-data.tsx
+++ b/yalla_london/app/components/structured-data.tsx
@@ -416,25 +416,57 @@ export function StructuredData({ type = 'website', data, language = 'en', siteId
     // it overrides all secondary sites in a multi-tenant deployment and must NOT
     // be used here. siteDomain (from getSiteDomain) is already correct per site.
     const baseUrl = siteDomain;
+    const currency = productData.currency || (siteCountry === 'UK' ? 'GBP' : 'USD');
+    const country = siteCountry === 'UK' ? 'GB' : (productData.country || 'GB');
+    const returnDays = productData.returnDays ?? 14;
     return {
       "@context": "https://schema.org",
       "@type": "Product",
       "name": productData.name || productData.title,
       "description": productData.description,
       "image": productData.image,
+      // Product.brand MUST use @type: "Brand" — Google flags "Organization" as invalid
       "brand": {
-        "@type": "Organization",
-        "name": siteName
+        "@type": "Brand",
+        "name": productData.brandName || siteName
       },
       "offers": {
         "@type": "Offer",
         "price": productData.price?.toString() || "0",
-        "priceCurrency": productData.currency || (siteCountry === 'UK' ? 'GBP' : 'USD'),
+        "priceCurrency": currency,
         "availability": productData.availability || "https://schema.org/InStock",
         "url": productData.url || baseUrl,
         "seller": {
           "@type": "Organization",
           "name": siteName
+        },
+        // Required by Google Merchant Listings since 2023.
+        // Digital-goods defaults (0 shipping, 14-day refund) — callers can
+        // override via productData.hasMerchantReturnPolicy / productData.shippingDetails.
+        "hasMerchantReturnPolicy": productData.hasMerchantReturnPolicy || {
+          "@type": "MerchantReturnPolicy",
+          "applicableCountry": country,
+          "returnPolicyCategory": "https://schema.org/MerchantReturnFiniteReturnWindow",
+          "merchantReturnDays": returnDays,
+          "returnMethod": "https://schema.org/ReturnByMail",
+          "returnFees": "https://schema.org/FreeReturn"
+        },
+        "shippingDetails": productData.shippingDetails || {
+          "@type": "OfferShippingDetails",
+          "shippingRate": {
+            "@type": "MonetaryAmount",
+            "value": "0",
+            "currency": currency
+          },
+          "shippingDestination": {
+            "@type": "DefinedRegion",
+            "addressCountry": country
+          },
+          "deliveryTime": {
+            "@type": "ShippingDeliveryTime",
+            "handlingTime": { "@type": "QuantitativeValue", "minValue": 0, "maxValue": 0, "unitCode": "DAY" },
+            "transitTime": { "@type": "QuantitativeValue", "minValue": 0, "maxValue": 0, "unitCode": "DAY" }
+          }
         }
       },
       "category": productData.category,

--- a/yalla_london/app/lib/seo/product-schema.ts
+++ b/yalla_london/app/lib/seo/product-schema.ts
@@ -1,0 +1,97 @@
+/**
+ * Product JSON-LD helpers aligned with Google's 2024+ Merchant Listing requirements.
+ *
+ * Google requires, on every Product Offer:
+ *   - brand.@type = "Brand" (NOT "Organization" — flagged as "invalid object type")
+ *   - hasMerchantReturnPolicy (MerchantReturnPolicy)
+ *   - shippingDetails (OfferShippingDetails)
+ *
+ * For digital goods (downloads, PDFs, digital guides) shippingRate is 0 and
+ * delivery is instant (0 days handling + 0 days transit).
+ *
+ * Refs:
+ *   https://developers.google.com/search/docs/appearance/structured-data/product
+ *   https://developers.google.com/search/docs/appearance/structured-data/merchant-return-policy
+ *   https://developers.google.com/search/docs/appearance/structured-data/product-shipping
+ */
+
+export type DigitalOfferInput = {
+  price: string | number;
+  priceCurrency?: string;
+  availability?: string;
+  url: string;
+  sellerName: string;
+  country?: string; // ISO-3166 alpha-2, defaults to "GB"
+  returnDays?: number; // defaults to 14
+};
+
+export type ProductSchemaInput = {
+  name: string;
+  description: string;
+  image: string;
+  brandName: string;
+  category?: string;
+  sku?: string;
+  offer: DigitalOfferInput;
+};
+
+export function buildDigitalShippingDetails(country = "GB", currency = "GBP") {
+  return {
+    "@type": "OfferShippingDetails",
+    shippingRate: {
+      "@type": "MonetaryAmount",
+      value: "0",
+      currency,
+    },
+    shippingDestination: {
+      "@type": "DefinedRegion",
+      addressCountry: country,
+    },
+    deliveryTime: {
+      "@type": "ShippingDeliveryTime",
+      handlingTime: { "@type": "QuantitativeValue", minValue: 0, maxValue: 0, unitCode: "DAY" },
+      transitTime: { "@type": "QuantitativeValue", minValue: 0, maxValue: 0, unitCode: "DAY" },
+    },
+  };
+}
+
+export function buildDigitalReturnPolicy(country = "GB", returnDays = 14) {
+  return {
+    "@type": "MerchantReturnPolicy",
+    applicableCountry: country,
+    returnPolicyCategory: "https://schema.org/MerchantReturnFiniteReturnWindow",
+    merchantReturnDays: returnDays,
+    returnMethod: "https://schema.org/ReturnByMail",
+    returnFees: "https://schema.org/FreeReturn",
+  };
+}
+
+export function buildDigitalOffer(offer: DigitalOfferInput) {
+  const currency = offer.priceCurrency || "GBP";
+  const country = offer.country || "GB";
+  return {
+    "@type": "Offer",
+    price: String(offer.price),
+    priceCurrency: currency,
+    availability: offer.availability || "https://schema.org/InStock",
+    url: offer.url,
+    seller: { "@type": "Organization", name: offer.sellerName },
+    hasMerchantReturnPolicy: buildDigitalReturnPolicy(country, offer.returnDays),
+    shippingDetails: buildDigitalShippingDetails(country, currency),
+  };
+}
+
+export function buildDigitalProductSchema(input: ProductSchemaInput) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: input.name,
+    description: input.description,
+    image: input.image,
+    // Product.brand MUST use @type: "Brand" — Google flags "Organization" as invalid
+    brand: { "@type": "Brand", name: input.brandName },
+    offers: buildDigitalOffer(input.offer),
+    ...(input.category ? { category: input.category } : {}),
+    ...(input.sku ? { sku: input.sku } : {}),
+  };
+}

--- a/yalla_london/app/lib/seo/redirect-map.ts
+++ b/yalla_london/app/lib/seo/redirect-map.ts
@@ -8,6 +8,13 @@
  * - Hash-suffix duplicates from content pipeline slug collision recovery
  * - Date-stamped variants of the same topic
  * - Near-identical articles that dilute ranking power
+ *
+ * IMPORTANT: Every target MUST be a published BlogPost. A 301 to a non-existent
+ * slug creates "page redirects" then 404 chains that Google caches for weeks
+ * and removes the source URL from the index.
+ *
+ * Verify before committing changes:
+ *   npx tsx scripts/validate-redirect-map.ts
  */
 
 export const BLOG_REDIRECTS: Record<string, string> = {

--- a/yalla_london/app/lib/sitemap-cache.ts
+++ b/yalla_london/app/lib/sitemap-cache.ts
@@ -104,8 +104,24 @@ export async function regenerateSitemapCache(siteId: string): Promise<{ urlCount
   const baseUrl = `https://${domain}`;
   const isYachtSite = checkIsYachtSite(siteId);
   const staticDate = "2026-02-19T00:00:00.000Z";
+  // Primary locale determines which URL is "rootless" and which is prefixed.
+  // EN-primary sites (yalla-london, zenitha-yachts): AR lives at /ar/path.
+  // AR-primary sites (arabaldives): AR lives at /path; EN (if ever added)
+  // would live at /en/path. Today arabaldives has no EN fallback, so we
+  // only emit the ar-SA hreflang for AR-primary sites.
+  const siteConfig = (await import("@/config/sites")).getSiteConfig(siteId);
+  const primaryLocale: "en" | "ar" = siteConfig?.locale === "ar" ? "ar" : "en";
 
   function hreflang(path: string) {
+    if (primaryLocale === "ar") {
+      const arUrl = path ? `${baseUrl}${path}` : baseUrl;
+      return {
+        languages: {
+          "ar-SA": arUrl,
+          "x-default": arUrl,
+        },
+      };
+    }
     const enUrl = path ? `${baseUrl}${path}` : baseUrl;
     const arUrl = path ? `${baseUrl}/ar${path}` : `${baseUrl}/ar`;
     return {

--- a/yalla_london/app/lib/sitemap-cache.ts
+++ b/yalla_london/app/lib/sitemap-cache.ts
@@ -165,15 +165,18 @@ export async function regenerateSitemapCache(siteId: string): Promise<{ urlCount
       ["/news", staticDate, "daily", 0.8],
       // High-value long-tail pages
       ["/halal-restaurants-london", staticDate, "weekly", 0.9],
-      ["/luxury-hotels-london", staticDate, "weekly", 0.9],
+      // /luxury-hotels-london is 301-redirected to /hotels by middleware (PAGE_REDIRECTS).
+      // Sitemaps must never list redirected URLs — triggers GSC "Page redirects" warnings.
       ["/london-with-kids", staticDate, "weekly", 0.9],
       // Structured data pages (DefinedTermSet, Service, FAQPage)
       ["/faq", staticDate, "monthly", 0.8],
       ["/glossary", staticDate, "monthly", 0.8],
       ["/halal-charter", staticDate, "monthly", 0.9],
       // Navigation & discovery
-      ["/destinations", staticDate, "weekly", 0.8],
-      ["/itineraries", staticDate, "weekly", 0.8],
+      // /destinations + /itineraries are yacht-charter features (query yachtDestination /
+      // charterItinerary tables, which are empty on blog sites). Listing them here
+      // produces soft 404s: Google crawls a 200 page with only an empty-state CTA.
+      // These are included only in isYachtSite above.
       ["/journal", staticDate, "weekly", 0.7],
       ["/shop", staticDate, "weekly", 0.7],
       ["/tools", staticDate, "monthly", 0.7],
@@ -293,8 +296,14 @@ export async function regenerateSitemapCache(siteId: string): Promise<{ urlCount
     return parts[1] || "";
   }));
 
-  // Blog posts from DB
+  // Blog posts from DB — filter out slugs that are in BLOG_REDIRECTS.
+  // Listing a redirected URL in the sitemap triggers GSC "Page redirects" warnings
+  // and wastes Google's crawl budget on a 301 bounce.
   try {
+    const { BLOG_REDIRECTS } = await import("@/lib/seo/redirect-map");
+    const redirectedSlugs = new Set<string>(
+      Object.keys(BLOG_REDIRECTS).map((path) => path.replace(/^\/blog\//, ""))
+    );
     const dbPosts = await prisma.blogPost.findMany({
       where: { published: true, deletedAt: null, siteId },
       select: { slug: true, updated_at: true },
@@ -303,6 +312,7 @@ export async function regenerateSitemapCache(siteId: string): Promise<{ urlCount
     });
     for (const post of dbPosts) {
       if (existingSlugs.has(post.slug)) continue;
+      if (redirectedSlugs.has(post.slug)) continue;
       const isRecent = post.updated_at && post.updated_at.getTime() > sevenDaysAgoMs;
       entries.push({
         url: `${baseUrl}/blog/${post.slug}`,

--- a/yalla_london/app/lib/url-utils.ts
+++ b/yalla_london/app/lib/url-utils.ts
@@ -1,31 +1,97 @@
 import { headers } from "next/headers";
-import { getSiteDomain, getDefaultSiteId } from "@/config/sites";
+import { getSiteDomain, getDefaultSiteId, getSiteConfig } from "@/config/sites";
+
+/**
+ * Read the site's primary locale from request headers (set by middleware
+ * based on hostname → tenant mapping). Falls back to the config default.
+ *
+ * - yalla-london, zenitha-yachts-med → "en"  (AR served under /ar/*)
+ * - arabaldives → "ar"                        (EN served under /en/* if added)
+ */
+async function getSitePrimaryLocale(): Promise<"en" | "ar"> {
+  try {
+    const h = await headers();
+    const headerLocale = h.get("x-site-locale");
+    if (headerLocale === "ar") return "ar";
+    if (headerLocale === "en") return "en";
+    const siteId = h.get("x-site-id") || getDefaultSiteId();
+    const config = getSiteConfig(siteId);
+    return config?.locale === "ar" ? "ar" : "en";
+  } catch {
+    return "en";
+  }
+}
+
+/**
+ * Effective content locale for the current request.
+ *
+ *   pathLocale ("ar" if URL has /ar/ prefix, else "en") + sitePrimaryLocale
+ *   → actual language of the content served at this URL.
+ *
+ * For EN-primary sites, root URLs serve English and /ar/* serves Arabic.
+ * For AR-primary sites (arabaldives), root URLs serve Arabic; /en/* would
+ * serve English if ever added. Until /en/* exists, root-URL AR-primary
+ * sites always resolve to "ar".
+ */
+async function getEffectiveLocale(): Promise<"en" | "ar"> {
+  try {
+    const h = await headers();
+    const pathLocale = h.get("x-locale") === "ar" ? "ar" : "en";
+    if (pathLocale === "ar") return "ar";
+    // EN path — but if site is AR-primary and URL has no /en/ prefix,
+    // the root URL actually serves Arabic.
+    const primary = await getSitePrimaryLocale();
+    return primary;
+  } catch {
+    return "en";
+  }
+}
+
+/**
+ * Per-site URL builder that produces the correct EN + AR URL for a base path,
+ * respecting the site's primary locale.
+ */
+async function getLocaleUrls(basePath: string): Promise<{ enUrl: string; arUrl: string; primary: "en" | "ar" }> {
+  const baseUrl = await getBaseUrl();
+  const primary = await getSitePrimaryLocale();
+  if (primary === "ar") {
+    // AR is canonical at root; EN fallback lives under /en/* (if/when added).
+    return {
+      arUrl: `${baseUrl}${basePath}`,
+      enUrl: `${baseUrl}/en${basePath}`,
+      primary,
+    };
+  }
+  return {
+    enUrl: `${baseUrl}${basePath}`,
+    arUrl: `${baseUrl}/ar${basePath}`,
+    primary,
+  };
+}
 
 /**
  * Get a locale-aware canonical URL.
- * Arabic pages (/ar prefix) get canonical pointing to /ar/..., English pages to /...
+ * Respects the site's primary locale — Arabic-primary sites canonicalize to
+ * the root URL, English-primary sites canonicalize to /ar/... for Arabic.
  */
 export async function getLocaleAwareCanonical(basePath: string = ""): Promise<string> {
-  const baseUrl = await getBaseUrl();
-  let locale = "en";
-  try {
-    const h = await headers();
-    locale = h.get("x-locale") || "en";
-  } catch {
-    // headers() not available during build
-  }
-  const prefix = locale === "ar" ? "/ar" : "";
-  return `${baseUrl}${prefix}${basePath}`;
+  const locale = await getEffectiveLocale();
+  const { enUrl, arUrl } = await getLocaleUrls(basePath);
+  return locale === "ar" ? arUrl : enUrl;
 }
 
 /**
  * Get the full `alternates` block for Next.js Metadata — canonical + hreflang
- * with correct per-locale URLs.
+ * with correct per-locale URLs AND the correct set of alternates for the
+ * site's URL structure.
  *
- * hreflang URLs MUST be absolute and point to the specific language version,
- * independent of which locale is currently being rendered. Google ignores
- * hreflang when an en-GB entry resolves to an Arabic URL (and vice versa),
- * causing "Duplicate — alternate page with canonical" in GSC.
+ * - EN-primary sites emit en-GB + ar-SA + x-default (EN is default).
+ * - AR-primary sites emit ar-SA + x-default (AR is default). en-GB is
+ *   omitted unless an /en/* fallback route is available on the platform.
+ *
+ * hreflang URLs MUST point to the actual language version. Google ignores
+ * hreflang when an en-GB entry resolves to the same URL as ar-SA, causing
+ * "Duplicate — alternate page with canonical" in GSC.
  *
  * Usage:
  *   const alternates = await getLocaleAlternates("/hotels");
@@ -35,17 +101,21 @@ export async function getLocaleAlternates(basePath: string = ""): Promise<{
   canonical: string;
   languages: Record<string, string>;
 }> {
-  const baseUrl = await getBaseUrl();
-  let locale = "en";
-  try {
-    const h = await headers();
-    locale = h.get("x-locale") || "en";
-  } catch {
-    // headers() not available during build
-  }
-  const enUrl = `${baseUrl}${basePath}`;
-  const arUrl = `${baseUrl}/ar${basePath}`;
+  const locale = await getEffectiveLocale();
+  const { enUrl, arUrl, primary } = await getLocaleUrls(basePath);
   const canonical = locale === "ar" ? arUrl : enUrl;
+  if (primary === "ar") {
+    // AR-primary site: emit only the languages that resolve to real content.
+    // en-GB would point at /en/* which does not yet exist — omitting it
+    // avoids promising Google an English version that returns 404.
+    return {
+      canonical,
+      languages: {
+        "ar-SA": arUrl,
+        "x-default": arUrl,
+      },
+    };
+  }
   return {
     canonical,
     languages: {

--- a/yalla_london/app/lib/url-utils.ts
+++ b/yalla_london/app/lib/url-utils.ts
@@ -19,6 +19,44 @@ export async function getLocaleAwareCanonical(basePath: string = ""): Promise<st
 }
 
 /**
+ * Get the full `alternates` block for Next.js Metadata — canonical + hreflang
+ * with correct per-locale URLs.
+ *
+ * hreflang URLs MUST be absolute and point to the specific language version,
+ * independent of which locale is currently being rendered. Google ignores
+ * hreflang when an en-GB entry resolves to an Arabic URL (and vice versa),
+ * causing "Duplicate — alternate page with canonical" in GSC.
+ *
+ * Usage:
+ *   const alternates = await getLocaleAlternates("/hotels");
+ *   return { ..., alternates };
+ */
+export async function getLocaleAlternates(basePath: string = ""): Promise<{
+  canonical: string;
+  languages: Record<string, string>;
+}> {
+  const baseUrl = await getBaseUrl();
+  let locale = "en";
+  try {
+    const h = await headers();
+    locale = h.get("x-locale") || "en";
+  } catch {
+    // headers() not available during build
+  }
+  const enUrl = `${baseUrl}${basePath}`;
+  const arUrl = `${baseUrl}/ar${basePath}`;
+  const canonical = locale === "ar" ? arUrl : enUrl;
+  return {
+    canonical,
+    languages: {
+      "en-GB": enUrl,
+      "ar-SA": arUrl,
+      "x-default": enUrl,
+    },
+  };
+}
+
+/**
  * Get the base URL for the current site context.
  * Priority: x-hostname header -> NEXT_PUBLIC_SITE_URL env -> config default
  *

--- a/yalla_london/app/scripts/validate-redirect-map.ts
+++ b/yalla_london/app/scripts/validate-redirect-map.ts
@@ -1,0 +1,128 @@
+/**
+ * Validate that every destination in BLOG_REDIRECTS + PAGE_REDIRECTS points
+ * to a published BlogPost or a real static route.
+ *
+ * A redirect to a nonexistent slug makes the middleware 301 to a 404, which
+ * Google caches as "Page redirects to a page with a 404" and drops the
+ * source URL from the index.
+ *
+ * Usage:
+ *   npx tsx scripts/validate-redirect-map.ts [--site=yalla-london]
+ *
+ * CI:
+ *   Exits with code 1 if any redirect target is broken.
+ *
+ * Admin trigger: can be POSTed from the cockpit via /api/admin/validate-redirects
+ * (wraps this same logic).
+ */
+import { prisma } from "@/lib/db";
+import { BLOG_REDIRECTS, PAGE_REDIRECTS } from "@/lib/seo/redirect-map";
+import { getDefaultSiteId, getActiveSiteIds } from "@/config/sites";
+
+type RedirectIssue = {
+  source: string;
+  target: string;
+  reason: string;
+};
+
+const STATIC_ROUTES = new Set<string>([
+  "/", "/hotels", "/experiences", "/recommendations", "/events", "/news",
+  "/blog", "/shop", "/itineraries", "/destinations", "/about", "/contact",
+  "/faq", "/glossary", "/halal-charter", "/halal-restaurants-london",
+  "/london-with-kids", "/london-by-foot", "/privacy", "/terms", "/team",
+  "/editorial-policy", "/affiliate-disclosure", "/how-it-works", "/journal",
+  "/charter-planner", "/fleet", "/yachts", "/inquiry", "/tools",
+  "/tools/seo-audit", "/information",
+]);
+
+async function validateBlogRedirectsForSite(siteId: string): Promise<RedirectIssue[]> {
+  const issues: RedirectIssue[] = [];
+
+  const uniqueTargets = new Set<string>(Object.values(BLOG_REDIRECTS));
+  const targetSlugs = [...uniqueTargets].map((path) => path.replace(/^\/blog\//, ""));
+
+  const published = await prisma.blogPost.findMany({
+    where: { siteId, published: true, deletedAt: null, slug: { in: targetSlugs } },
+    select: { slug: true },
+  });
+  const publishedSet = new Set(published.map((p) => p.slug));
+
+  for (const [source, target] of Object.entries(BLOG_REDIRECTS)) {
+    const targetSlug = target.replace(/^\/blog\//, "");
+    if (!publishedSet.has(targetSlug)) {
+      issues.push({
+        source,
+        target,
+        reason: `Target blog slug "${targetSlug}" is not a published BlogPost for site "${siteId}"`,
+      });
+    }
+    if (BLOG_REDIRECTS[target]) {
+      issues.push({
+        source,
+        target,
+        reason: `Redirect CHAIN: target "${target}" is itself a redirect source (loop risk)`,
+      });
+    }
+  }
+
+  for (const [source, target] of Object.entries(PAGE_REDIRECTS)) {
+    if (STATIC_ROUTES.has(target)) continue;
+    issues.push({
+      source,
+      target,
+      reason: `Target "${target}" is not in STATIC_ROUTES — verify it is a real route`,
+    });
+  }
+
+  return issues;
+}
+
+export async function validateRedirectMap(siteId?: string): Promise<{
+  siteId: string;
+  totalRedirects: number;
+  issues: RedirectIssue[];
+}> {
+  const effectiveSiteId = siteId || getDefaultSiteId();
+  const issues = await validateBlogRedirectsForSite(effectiveSiteId);
+  return {
+    siteId: effectiveSiteId,
+    totalRedirects: Object.keys(BLOG_REDIRECTS).length + Object.keys(PAGE_REDIRECTS).length,
+    issues,
+  };
+}
+
+async function main() {
+  const arg = process.argv.find((a) => a.startsWith("--site="));
+  const siteIds = arg ? [arg.replace("--site=", "")] : getActiveSiteIds();
+
+  let totalIssues = 0;
+  for (const siteId of siteIds) {
+    const result = await validateRedirectMap(siteId);
+    console.log(`\n=== ${siteId} (${result.totalRedirects} redirects) ===`);
+    if (result.issues.length === 0) {
+      console.log("  All redirect targets valid ✓");
+    } else {
+      console.log(`  ${result.issues.length} issue(s):`);
+      for (const issue of result.issues) {
+        console.log(`    ✗ ${issue.source}`);
+        console.log(`      → ${issue.target}`);
+        console.log(`      ${issue.reason}`);
+      }
+      totalIssues += result.issues.length;
+    }
+  }
+
+  await prisma.$disconnect();
+  if (totalIssues > 0) {
+    console.error(`\n${totalIssues} broken redirect(s). Fix before deploying.`);
+    process.exit(1);
+  }
+  console.log("\nAll redirects validated ✓");
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Root cause: Product JSON-LD used brand.@type="Organization" (Google flags as
invalid — Product.brand must be @type="Brand") and omitted hasMerchantReturnPolicy
+ shippingDetails on every Offer (required by Google Merchant Listings since 2023).

GSC flagged all 6 /shop products on yalla-london.com. Same bug in the shared
helper components/structured-data.tsx:getProductStructuredData() would repeat the
issue on any future Product page.

Fix:
- Add lib/seo/product-schema.ts with buildDigitalProductSchema() as single
  source of truth for digital-goods Product schema (zero shipping, 14-day refund)
- app/shop/layout.tsx: switch the 6 SHOP_PRODUCTS to the helper
- components/structured-data.tsx: fix getProductStructuredData() to emit
  Brand type and merchant-listing fields with digital-goods defaults

https://claude.ai/code/session_01LSGXsUWCnz7V3TGFzuLUdb