### PR TITLE
fix(affiliate): unify click counting across CjClickEvent + AuditLog direct clicks

### DIFF
--- a/yalla_london/app/app/api/admin/affiliate-hq/route.ts
+++ b/yalla_london/app/app/api/admin/affiliate-hq/route.ts
@@ -53,6 +53,10 @@ export async function GET(request: NextRequest) {
     "@/lib/affiliate/cj-client"
   );
   const { getDefaultSiteId } = await import("@/config/sites");
+  const { getClickSummary, getClicksByArticle, getClicksByDay } = await import(
+    "@/lib/affiliate/click-aggregator"
+  );
+  const { hasAnyAffiliateMarker } = await import("@/lib/affiliate/partner-detector");
 
   const siteId = request.nextUrl.searchParams.get("siteId") || getDefaultSiteId();
   const start = Date.now();
@@ -90,18 +94,21 @@ export async function GET(request: NextRequest) {
     const revPrev30 = commissionsPrev30d._sum.commissionAmount || 0;
     const revTrend = revPrev30 > 0 ? ((rev30 - revPrev30) / revPrev30) * 100 : 0;
 
-    const clickSiteFilter = siteId ? { OR: [{ siteId }, { siteId: null }] } : {};
-    const clicks7d = await prisma.cjClickEvent.count({
-      where: { createdAt: { gte: d7 }, ...clickSiteFilter },
-    });
-
-    const topAdvertisers = await prisma.cjCommission.groupBy({
-      by: ["advertiserId"],
-      where: { networkId: CJ_NETWORK_ID, eventDate: { gte: d30 }, ...siteFilter },
-      _sum: { commissionAmount: true },
-      orderBy: { _sum: { commissionAmount: "desc" } },
-      take: 10,
-    });
+    // Unified click counts — CjClickEvent (CJ linkId-based) + AuditLog (direct URL, Travelpayouts/static)
+    const [clicks7dSummary, clicks30dSummary, clicksByDayArr, articleClicks, topAdvertisers] = await Promise.all([
+      getClickSummary({ siteId, since: d7 }),
+      getClickSummary({ siteId, since: d30 }),
+      getClicksByDay({ siteId }, 30),
+      getClicksByArticle({ siteId, since: d30 }),
+      prisma.cjCommission.groupBy({
+        by: ["advertiserId"],
+        where: { networkId: CJ_NETWORK_ID, eventDate: { gte: d30 }, ...siteFilter },
+        _sum: { commissionAmount: true },
+        orderBy: { _sum: { commissionAmount: "desc" } },
+        take: 10,
+      }),
+    ]);
+    const clicks7d = clicks7dSummary.total;
 
     const advIds = topAdvertisers.map((a) => a.advertiserId);
     const advNames = advIds.length > 0
@@ -109,47 +116,25 @@ export async function GET(request: NextRequest) {
       : [];
     const nameMap = new Map(advNames.map((a: { id: string; name: string }) => [a.id, a.name]));
 
-    const topClicks = await prisma.cjClickEvent.groupBy({
-      by: ["pageUrl"],
-      where: { createdAt: { gte: d30 }, ...clickSiteFilter },
-      _count: true,
-      orderBy: { _count: { pageUrl: "desc" } },
-      take: 10,
-    });
+    // Top articles by clicks — merges CJ + direct from aggregator
+    const topClicks = [...articleClicks.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([slug, count]) => ({ url: `/blog/${slug}`, clicks: count }));
 
-    // ── Per-network attribution: CJ clicks + commissions vs Travelpayouts/Stay22 (audit log clicks) ──
-    const [cjClicks30d, auditClicks30d, clicksByDayRaw] = await Promise.all([
-      prisma.cjClickEvent.count({
-        where: { createdAt: { gte: d30 }, ...clickSiteFilter },
-      }),
-      prisma.auditLog.count({
-        where: { action: "affiliate_click", timestamp: { gte: d30 }, ...(siteId ? { details: { path: ["siteId"], equals: siteId } } : {}) },
-      }),
-      prisma.cjClickEvent.groupBy({
-        by: ["createdAt"],
-        where: { createdAt: { gte: d30 }, ...clickSiteFilter },
-        _count: true,
-        orderBy: { createdAt: "asc" },
-      }),
-    ]);
+    const clicksByDay: Array<{ date: string; clicks: number }> = clicksByDayArr.map((d) => ({
+      date: d.date,
+      clicks: d.count,
+    }));
 
-    // Bucket clicks by date (CJ only — audit log clicks aggregated separately)
-    const clickDayMap = new Map<string, number>();
-    for (const row of clicksByDayRaw) {
-      const day = new Date(row.createdAt).toISOString().slice(0, 10);
-      clickDayMap.set(day, (clickDayMap.get(day) || 0) + row._count);
-    }
-    const clicksByDay: Array<{ date: string; clicks: number }> = [];
-    for (let i = 29; i >= 0; i--) {
-      const d = new Date(Date.now() - i * 86400_000).toISOString().slice(0, 10);
-      clicksByDay.push({ date: d, clicks: clickDayMap.get(d) || 0 });
-    }
+    // ── Per-network attribution: CJ (CjClickEvent) vs Direct (AuditLog AFFILIATE_CLICK_DIRECT) ──
+    const cjClicks30d = clicks30dSummary.cjClicks;
+    const directClicks30d = clicks30dSummary.directClicks;
 
     const cjConvRate = cjClicks30d > 0 ? ((commissions30d._count || 0) / cjClicks30d) * 100 : 0;
     const byNetwork = [
       { network: "CJ Affiliate", clicks30d: cjClicks30d, commissions30d: rev30, conversionRate: Math.round(cjConvRate * 10) / 10 },
-      { network: "Travelpayouts", clicks30d: auditClicks30d, commissions30d: 0, conversionRate: 0 },
-      { network: "Stay22", clicks30d: 0, commissions30d: 0, conversionRate: 0 },
+      { network: "Direct (Travelpayouts/Stay22/static)", clicks30d: directClicks30d, commissions30d: 0, conversionRate: 0 },
     ].filter(n => n.clicks30d > 0 || n.commissions30d > 0 || n.network === "CJ Affiliate");
 
     revenue = {
@@ -162,10 +147,7 @@ export async function GET(request: NextRequest) {
         name: nameMap.get(a.advertiserId) || "Unknown",
         commission: a._sum.commissionAmount || 0,
       })),
-      topArticlesByClicks: topClicks.map((c) => ({
-        url: c.pageUrl,
-        clicks: c._count,
-      })),
+      topArticlesByClicks: topClicks,
       byNetwork,
       clicksByDay,
     };
@@ -251,18 +233,21 @@ export async function GET(request: NextRequest) {
       take: 200,
     });
 
-    // Get all click events grouped by pageUrl
-    const clickEvents = await prisma.cjClickEvent.findMany({
-      where: siteId ? { OR: [{ siteId }, { siteId: null }] } : {},
-      select: { pageUrl: true, linkId: true },
-    });
+    // Unified per-article click counts (CjClickEvent + AuditLog direct)
+    const pageClickMap = await getClicksByArticle({ siteId });
 
-    // Build page→clicks map and page→linkIds map
-    const pageClickMap = new Map<string, number>();
+    // Build a CJ-only linkId map for revenue attribution (direct clicks have no linkId)
+    const cjClickEvents = await prisma.cjClickEvent.findMany({
+      where: siteId ? { OR: [{ siteId }, { siteId: null }] } : {},
+      select: { pageUrl: true, linkId: true, sessionId: true },
+    });
     const pageLinkIdsMap = new Map<string, Set<string>>();
-    for (const ev of clickEvents) {
-      const slug = ev.pageUrl.replace(/^https?:\/\/[^/]+/, "").replace(/\/$/, "").replace(/^\/blog\//, "");
-      pageClickMap.set(slug, (pageClickMap.get(slug) || 0) + 1);
+    for (const ev of cjClickEvents) {
+      const fromUrl = ev.pageUrl?.match(/\/blog\/([^/?#]+)/)?.[1] || null;
+      const fromSession =
+        ev.sessionId?.includes("_") ? ev.sessionId.split("_").slice(1).join("_") : null;
+      const slug = fromUrl || fromSession;
+      if (!slug) continue;
       if (!pageLinkIdsMap.has(slug)) pageLinkIdsMap.set(slug, new Set<string>());
       pageLinkIdsMap.get(slug)!.add(ev.linkId);
     }
@@ -292,14 +277,13 @@ export async function GET(request: NextRequest) {
     const linkAdvertiserMap = new Map<string, string>();
     for (const l of cjLinks) linkAdvertiserMap.set(l.id, l.advertiser.name);
 
-    const affiliatePatterns = ['rel="sponsored', "affiliate-cta-block", "affiliate-recommendation", 'rel="noopener sponsored"'];
-
     let withAffiliatesCount = 0;
     const uncoveredArticles: Array<{ id: string; title: string; slug: string; createdAt: Date }> = [];
 
     const pages = allArticles.map((article) => {
       const content = article.content_en || "";
-      const hasAffiliateLinks = affiliatePatterns.some((p) => content.includes(p));
+      // Shared affiliate-marker detector — kept in sync with injection cron
+      const hasAffiliateLinks = hasAnyAffiliateMarker(content);
       if (hasAffiliateLinks) withAffiliatesCount++;
       else uncoveredArticles.push({ id: article.id, title: article.title_en, slug: article.slug, createdAt: article.created_at });
 

--- a/yalla_london/app/app/api/admin/affiliate-monitor/route.ts
+++ b/yalla_london/app/app/api/admin/affiliate-monitor/route.ts
@@ -97,92 +97,37 @@ export async function GET(request: NextRequest) {
       : 0;
 
     // -----------------------------------------------------------------------
-    // 4. Top articles by clicks (last 30d)
+    // 4. Top articles by clicks (last 30d) — unified CJ + direct URL clicks
     // -----------------------------------------------------------------------
-    const recentClicks = await prisma.cjClickEvent.findMany({
-      where: { ...siteFilter, createdAt: { gte: d30 } },
-      select: { sessionId: true, createdAt: true },
-      orderBy: { createdAt: "desc" },
-      take: 500,
-    });
-
-    // Group by article slug (sessionId format: siteId_articleSlug)
-    const articleClickMap = new Map<string, number>();
-    for (const click of recentClicks) {
-      if (!click.sessionId?.includes("_")) continue;
-      const slug = click.sessionId.split("_").slice(1).join("_");
-      articleClickMap.set(slug, (articleClickMap.get(slug) || 0) + 1);
-    }
-
+    const { getClicksByArticle, getClicksByPartner, getRecentClickFeed } = await import(
+      "@/lib/affiliate/click-aggregator"
+    );
+    const articleClickMap = await getClicksByArticle({ siteId, since: d30 });
     const topArticles = [...articleClickMap.entries()]
       .sort((a, b) => b[1] - a[1])
       .slice(0, 10)
       .map(([slug, clicks]) => ({ slug, clicks }));
 
     // -----------------------------------------------------------------------
-    // 5. Per-partner breakdown
+    // 5. Per-partner breakdown — unified CJ + direct
     // -----------------------------------------------------------------------
-    const clicksWithLinks = await prisma.cjClickEvent.findMany({
-      where: { ...siteFilter, createdAt: { gte: d30 } },
-      select: { linkId: true },
-      take: 1000,
-    });
-
-    // Get link details for partner attribution
-    const linkIds = [...new Set<string>(clicksWithLinks.map(c => c.linkId))];
-    const links = linkIds.length > 0
-      ? await prisma.cjLink.findMany({
-          where: { id: { in: linkIds } },
-          select: { id: true, advertiserName: true },
-        })
-      : [];
-    const linkNameMap = new Map<string, string>(links.map(l => [l.id, l.advertiserName || "Unknown"]));
-
-    const partnerClickMap = new Map<string, number>();
-    for (const click of clicksWithLinks) {
-      const partner = linkNameMap.get(click.linkId) || "Unknown";
-      partnerClickMap.set(partner, (partnerClickMap.get(partner) || 0) + 1);
-    }
-
+    const partnerClickMap = await getClicksByPartner({ siteId, since: d30 });
     const partnerBreakdown = [...partnerClickMap.entries()]
       .sort((a, b) => b[1] - a[1])
       .map(([partner, clicks]) => ({ partner, clicks }));
 
     // -----------------------------------------------------------------------
-    // 6. Recent click feed (last 20)
+    // 6. Recent click feed (last 20) — unified CJ + direct
     // -----------------------------------------------------------------------
-    const recentClickFeed = await prisma.cjClickEvent.findMany({
-      where: siteFilter,
-      orderBy: { createdAt: "desc" },
-      take: 20,
-      select: {
-        id: true,
-        linkId: true,
-        pageUrl: true,
-        device: true,
-        country: true,
-        createdAt: true,
-        sessionId: true,
-      },
-    });
-
-    // Enrich with partner names
-    const feedLinkIds = [...new Set<string>(recentClickFeed.map(c => c.linkId))];
-    const feedLinks = feedLinkIds.length > 0
-      ? await prisma.cjLink.findMany({
-          where: { id: { in: feedLinkIds } },
-          select: { id: true, advertiserName: true },
-        })
-      : [];
-    const feedLinkNameMap = new Map(feedLinks.map(l => [l.id, l.advertiserName || "Unknown"]));
-
-    const clickFeed = recentClickFeed.map(c => ({
+    const feedItems = await getRecentClickFeed({ siteId }, 20);
+    const clickFeed = feedItems.map((c) => ({
       id: c.id,
-      partner: feedLinkNameMap.get(c.linkId) || "Unknown",
-      article: c.sessionId?.includes("_") ? c.sessionId.split("_").slice(1).join("_") : null,
+      partner: c.partner,
+      article: c.articleSlug,
       device: c.device,
       country: c.country,
-      timestamp: c.createdAt.toISOString(),
+      timestamp: c.timestamp.toISOString(),
+      source: c.source,
     }));
 
     // -----------------------------------------------------------------------
@@ -284,6 +229,15 @@ export async function GET(request: NextRequest) {
         issue: "Zero affiliate clicks in 30 days — this could mean: (a) articles have no affiliate links injected, (b) no traffic yet, or (c) links use direct partner URLs instead of /api/affiliate/click tracking redirect",
         severity: "info",
         fix: "Verify by visiting a published article and inspecting the affiliate link href. It should start with /api/affiliate/click to be tracked.",
+      });
+    }
+
+    // Surface attribution pattern — helps explain where revenue lives
+    if (cjClicks30d === 0 && direct30d > 0) {
+      diagnostics.push({
+        issue: `All ${direct30d} clicks in the last 30 days are direct URL redirects (Travelpayouts/static/Vrbo-fallback). Revenue attribution lives in those networks' dashboards, not in CjCommission.`,
+        severity: "info",
+        fix: "This is expected until more CJ advertisers (Booking.com, GetYourGuide) are approved. Check Travelpayouts dashboard (marker 510776) for commission data.",
       });
     }
 

--- a/yalla_london/app/app/api/admin/aggregated-report/route.ts
+++ b/yalla_london/app/app/api/admin/aggregated-report/route.ts
@@ -721,7 +721,9 @@ export async function GET(request: NextRequest) {
         const { isCjConfigured, CJ_NETWORK_ID } = await import("@/lib/affiliate/cj-client");
         if (isCjConfigured()) {
           const d30 = new Date(Date.now() - 30 * 86400_000);
-          const [joinedAdvs, activeLinks, commissions30d, clicks7d, lastSyncs] = await Promise.all([
+          const d7 = new Date(Date.now() - 7 * 86400_000);
+          const { getClickSummary } = await import("@/lib/affiliate/click-aggregator");
+          const [joinedAdvs, activeLinks, commissions30d, clicks7dSummary, lastSyncs] = await Promise.all([
             prisma.cjAdvertiser.count({ where: { networkId: CJ_NETWORK_ID, status: "JOINED" } }),
             prisma.cjLink.count({ where: { advertiser: { networkId: CJ_NETWORK_ID }, isActive: true } }),
             prisma.cjCommission.aggregate({
@@ -729,7 +731,8 @@ export async function GET(request: NextRequest) {
               _sum: { commissionAmount: true },
               _count: true,
             }),
-            prisma.cjClickEvent.count({ where: { createdAt: { gte: new Date(Date.now() - 7 * 86400_000) } } }),
+            // Unified click count (CjClickEvent + AuditLog AFFILIATE_CLICK_DIRECT)
+            getClickSummary({ siteId, since: d7 }),
             prisma.cjSyncLog.findMany({
               where: { networkId: CJ_NETWORK_ID },
               orderBy: { createdAt: "desc" },
@@ -737,22 +740,21 @@ export async function GET(request: NextRequest) {
               select: { syncType: true, status: true, createdAt: true },
             }),
           ]);
+          const clicks7d = clicks7dSummary.total;
 
-          // Coverage %
+          // Coverage % — shared affiliate-marker detector (synced with injection cron)
           let coveragePercent = 0;
           const totalPublished = await prisma.blogPost.count({
             where: { published: true, deletedAt: null, siteId },
           });
           if (totalPublished > 0) {
+            const { AFFILIATE_MARKERS } = await import("@/lib/affiliate/partner-detector");
             const withAffiliates = await prisma.blogPost.count({
               where: {
                 published: true, deletedAt: null, siteId,
-                OR: [
-                  { content_en: { contains: 'rel="sponsored' } },
-                  { content_en: { contains: "affiliate-recommendation" } },
-                  { content_en: { contains: 'rel="noopener sponsored"' } },
-                  { content_en: { contains: "data-affiliate-id" } },
-                ],
+                OR: AFFILIATE_MARKERS.map((marker) => ({
+                  content_en: { contains: marker },
+                })),
               },
             });
             coveragePercent = Math.round((withAffiliates / totalPublished) * 100);

--- a/yalla_london/app/app/api/admin/cockpit/route.ts
+++ b/yalla_london/app/app/api/admin/cockpit/route.ts
@@ -1077,6 +1077,12 @@ async function buildRevenue(prisma: any, activeSiteIds: string[]): Promise<Reven
       ? `("siteId" IN (${siteParams.map((_, i) => `$${i + 3}`).join(",")}) OR "siteId" IS NULL)`
       : "1=1";
 
+    // AuditLog direct-URL clicks are keyed on details->>'siteId' (JSONB).
+    // When activeSiteIds is empty, match any siteId (all sites).
+    const auditSiteClause = siteParams.length
+      ? `(details->>'siteId') IN (${siteParams.map((_, i) => `$${i + 3}`).join(",")})`
+      : "1=1";
+
     // Single raw SQL replacing 8 separate queries
     const rows = await prisma.$queryRawUnsafe(`
       SELECT
@@ -1088,12 +1094,20 @@ async function buildRevenue(prisma: any, activeSiteIds: string[]): Promise<Reven
         (SELECT COUNT(*)::int FROM "cj_click_events" WHERE ${cjSiteIn} AND "createdAt" >= $1) AS cj_clicks_today,
         (SELECT COUNT(*)::int FROM "cj_click_events" WHERE ${cjSiteIn} AND "createdAt" >= $2) AS cj_clicks_week,
         (SELECT COUNT(*)::int FROM "cj_commissions" WHERE ${cjSiteIn} AND "eventDate" >= $2) AS cj_conversions,
-        (SELECT COALESCE(SUM("commissionAmount"),0) FROM "cj_commissions" WHERE ${cjSiteIn} AND "eventDate" >= $2) AS cj_revenue
+        (SELECT COALESCE(SUM("commissionAmount"),0) FROM "cj_commissions" WHERE ${cjSiteIn} AND "eventDate" >= $2) AS cj_revenue,
+        (SELECT COUNT(*)::int FROM "audit_log" WHERE action = 'AFFILIATE_CLICK_DIRECT' AND ${auditSiteClause} AND "timestamp" >= $1) AS direct_clicks_today,
+        (SELECT COUNT(*)::int FROM "audit_log" WHERE action = 'AFFILIATE_CLICK_DIRECT' AND ${auditSiteClause} AND "timestamp" >= $2) AS direct_clicks_week
     `, todayStart, weekAgo, ...siteParams) as any[];
 
     const r = rows[0] || {};
-    snapshot.affiliateClicksToday = Number(r.clicks_today ?? 0) + Number(r.cj_clicks_today ?? 0);
-    snapshot.affiliateClicksWeek = Number(r.clicks_week ?? 0) + Number(r.cj_clicks_week ?? 0);
+    snapshot.affiliateClicksToday =
+      Number(r.clicks_today ?? 0) +
+      Number(r.cj_clicks_today ?? 0) +
+      Number(r.direct_clicks_today ?? 0);
+    snapshot.affiliateClicksWeek =
+      Number(r.clicks_week ?? 0) +
+      Number(r.cj_clicks_week ?? 0) +
+      Number(r.direct_clicks_week ?? 0);
     snapshot.conversionsWeek = Number(r.conversions_week ?? 0) + Number(r.cj_conversions ?? 0);
     snapshot.revenueWeekUsd = Math.round(Number(r.revenue_cents ?? 0)) / 100
       + Math.round(Number(r.cj_revenue ?? 0) * 100) / 100;

--- a/yalla_london/app/lib/affiliate/click-aggregator.ts
+++ b/yalla_london/app/lib/affiliate/click-aggregator.ts
@@ -1,0 +1,337 @@
+/**
+ * Click Aggregator — Unified click-query helpers across CjClickEvent and AuditLog.
+ *
+ * The affiliate-injection cron wraps all partner URLs through `/api/affiliate/click`.
+ * That endpoint has two write paths:
+ *
+ *   1. CjLink-based (id= param)    → writes to `cj_click_events` with linkId FK
+ *   2. Direct URL (url= param)     → writes to `audit_log` with action=AFFILIATE_CLICK_DIRECT
+ *                                     (direct URLs have no CjLink record; the FK forbids it)
+ *
+ * Historically, every dashboard queried `cj_click_events` only, so all Travelpayouts,
+ * Vrbo fallback, Welcome Pickups, Tiqets, TicketNetwork, and static-rule clicks were
+ * invisible despite being recorded.
+ *
+ * This module unifies the two sources. Use it wherever a dashboard needs a click count.
+ */
+
+// Narrow where-clause types — we avoid importing the Prisma namespace
+// (not exported from @prisma/client in this codebase's version) and instead
+// rely on Prisma's runtime accepting these plain object shapes.
+type CjEventWhere = {
+  OR?: Array<{ siteId?: string | null }>;
+  createdAt?: { gte: Date };
+};
+type AuditWhere = {
+  action: string;
+  timestamp?: { gte: Date };
+  details?: { path: string[]; equals: string };
+};
+
+export type ClickFilters = {
+  siteId?: string;
+  since?: Date;
+  articleSlug?: string;
+  partner?: string;
+};
+
+export type ClickSummary = {
+  cjClicks: number;
+  directClicks: number;
+  total: number;
+};
+
+export type ClickFeedItem = {
+  id: string;
+  source: "cj" | "direct";
+  partner: string;
+  articleSlug: string | null;
+  pageUrl: string | null;
+  device: string | null;
+  country: string | null;
+  timestamp: Date;
+  sessionId: string | null;
+};
+
+// ── Shared helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Build a Prisma `where` filter for CjClickEvent using the OR-null pattern.
+ * Includes records scoped to this site OR legacy records with null siteId.
+ */
+function cjSiteFilter(siteId?: string): CjEventWhere {
+  return siteId ? { OR: [{ siteId }, { siteId: null }] } : {};
+}
+
+/**
+ * Build a Prisma `where` filter for AuditLog direct affiliate clicks.
+ * Uses JSONB path operators to filter on `details.siteId`.
+ */
+function auditSiteFilter(siteId?: string): AuditWhere {
+  const base: AuditWhere = { action: "AFFILIATE_CLICK_DIRECT" };
+  if (!siteId) return base;
+  return {
+    ...base,
+    details: { path: ["siteId"], equals: siteId },
+  };
+}
+
+/** Parse article slug from an AuditLog details.sessionId (format: "siteId_articleSlug"). */
+function parseSlugFromSession(sessionId: unknown): string | null {
+  if (typeof sessionId !== "string" || !sessionId.includes("_")) return null;
+  return sessionId.split("_").slice(1).join("_") || null;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Total click count summary for the given filters.
+ * Runs both queries in parallel.
+ */
+export async function getClickSummary(filters: ClickFilters = {}): Promise<ClickSummary> {
+  const { prisma } = await import("@/lib/db");
+
+  const cjWhere: CjEventWhere = { ...cjSiteFilter(filters.siteId) };
+  if (filters.since) cjWhere.createdAt = { gte: filters.since };
+
+  const auditWhere: AuditWhere = { ...auditSiteFilter(filters.siteId) };
+  if (filters.since) auditWhere.timestamp = { gte: filters.since };
+
+  const [cjClicks, directClicks] = await Promise.all([
+    prisma.cjClickEvent.count({ where: cjWhere }),
+    prisma.auditLog.count({ where: auditWhere }),
+  ]);
+
+  return { cjClicks, directClicks, total: cjClicks + directClicks };
+}
+
+/**
+ * Clicks grouped by article slug. Returns Map<slug, count>.
+ * Parses slug from pageUrl OR sessionId (CjClickEvent) and sessionId (AuditLog).
+ */
+export async function getClicksByArticle(filters: ClickFilters = {}): Promise<Map<string, number>> {
+  const { prisma } = await import("@/lib/db");
+
+  const cjWhere: CjEventWhere = { ...cjSiteFilter(filters.siteId) };
+  if (filters.since) cjWhere.createdAt = { gte: filters.since };
+
+  const auditWhere: AuditWhere = { ...auditSiteFilter(filters.siteId) };
+  if (filters.since) auditWhere.timestamp = { gte: filters.since };
+
+  const [cjClicks, auditClicks] = await Promise.all([
+    prisma.cjClickEvent.findMany({
+      where: cjWhere,
+      select: { pageUrl: true, sessionId: true },
+      take: 5000,
+    }),
+    prisma.auditLog.findMany({
+      where: auditWhere,
+      select: { details: true },
+      take: 5000,
+    }),
+  ]);
+
+  const byArticle = new Map<string, number>();
+
+  const bump = (slug: string | null) => {
+    if (!slug || slug === "unknown") return;
+    byArticle.set(slug, (byArticle.get(slug) || 0) + 1);
+  };
+
+  for (const c of cjClicks) {
+    const fromUrl = c.pageUrl?.match(/\/blog\/([^/?#]+)/)?.[1] || null;
+    bump(fromUrl || parseSlugFromSession(c.sessionId));
+  }
+
+  for (const c of auditClicks) {
+    const details = (c.details ?? {}) as Record<string, unknown>;
+    bump(parseSlugFromSession(details.sessionId));
+  }
+
+  return byArticle;
+}
+
+/**
+ * Clicks grouped by partner name. Returns Map<partner, count>.
+ * Requires a CjLink lookup for CJ clicks (advertiser name) and
+ * reads `details.partner` from AuditLog.
+ */
+export async function getClicksByPartner(filters: ClickFilters = {}): Promise<Map<string, number>> {
+  const { prisma } = await import("@/lib/db");
+
+  const cjWhere: CjEventWhere = { ...cjSiteFilter(filters.siteId) };
+  if (filters.since) cjWhere.createdAt = { gte: filters.since };
+
+  const auditWhere: AuditWhere = { ...auditSiteFilter(filters.siteId) };
+  if (filters.since) auditWhere.timestamp = { gte: filters.since };
+
+  const [cjClicks, auditClicks] = await Promise.all([
+    prisma.cjClickEvent.findMany({
+      where: cjWhere,
+      select: { linkId: true },
+      take: 5000,
+    }),
+    prisma.auditLog.findMany({
+      where: auditWhere,
+      select: { details: true },
+      take: 5000,
+    }),
+  ]);
+
+  const byPartner = new Map<string, number>();
+
+  // Resolve CJ link IDs → advertiser names
+  const linkIds = [...new Set<string>(cjClicks.map((c) => c.linkId))];
+  if (linkIds.length > 0) {
+    const links = await prisma.cjLink.findMany({
+      where: { id: { in: linkIds } },
+      select: { id: true, advertiserName: true, advertiser: { select: { name: true } } },
+    });
+    const linkToPartner = new Map<string, string>(
+      links.map((l) => [l.id, l.advertiserName || l.advertiser?.name || "CJ (unknown)"]),
+    );
+    for (const c of cjClicks) {
+      const partner = linkToPartner.get(c.linkId) || "CJ (unknown)";
+      byPartner.set(partner, (byPartner.get(partner) || 0) + 1);
+    }
+  }
+
+  for (const c of auditClicks) {
+    const details = (c.details ?? {}) as Record<string, unknown>;
+    const partner = (typeof details.partner === "string" ? details.partner : null) || "direct (unknown)";
+    byPartner.set(partner, (byPartner.get(partner) || 0) + 1);
+  }
+
+  return byPartner;
+}
+
+/**
+ * Per-day click buckets for the last N days.
+ * Returns [{ date: "YYYY-MM-DD", count }] with zero-filled missing days.
+ */
+export async function getClicksByDay(
+  filters: ClickFilters = {},
+  days: number,
+): Promise<Array<{ date: string; count: number }>> {
+  const { prisma } = await import("@/lib/db");
+
+  const since = filters.since ?? new Date(Date.now() - days * 86400_000);
+  const cjWhere: CjEventWhere = {
+    ...cjSiteFilter(filters.siteId),
+    createdAt: { gte: since },
+  };
+  const auditWhere: AuditWhere = {
+    ...auditSiteFilter(filters.siteId),
+    timestamp: { gte: since },
+  };
+
+  const [cjClicks, auditClicks] = await Promise.all([
+    prisma.cjClickEvent.findMany({
+      where: cjWhere,
+      select: { createdAt: true },
+      take: 10000,
+    }),
+    prisma.auditLog.findMany({
+      where: auditWhere,
+      select: { timestamp: true },
+      take: 10000,
+    }),
+  ]);
+
+  const buckets = new Map<string, number>();
+  for (const c of cjClicks) {
+    const day = c.createdAt.toISOString().slice(0, 10);
+    buckets.set(day, (buckets.get(day) || 0) + 1);
+  }
+  for (const c of auditClicks) {
+    const day = c.timestamp.toISOString().slice(0, 10);
+    buckets.set(day, (buckets.get(day) || 0) + 1);
+  }
+
+  // Zero-fill missing days
+  const result: Array<{ date: string; count: number }> = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(Date.now() - i * 86400_000).toISOString().slice(0, 10);
+    result.push({ date: d, count: buckets.get(d) || 0 });
+  }
+  return result;
+}
+
+/**
+ * Recent click feed — merges CJ and direct clicks, sorted by timestamp desc.
+ */
+export async function getRecentClickFeed(filters: ClickFilters = {}, limit: number = 20): Promise<ClickFeedItem[]> {
+  const { prisma } = await import("@/lib/db");
+
+  const cjWhere: CjEventWhere = { ...cjSiteFilter(filters.siteId) };
+  if (filters.since) cjWhere.createdAt = { gte: filters.since };
+
+  const auditWhere: AuditWhere = { ...auditSiteFilter(filters.siteId) };
+  if (filters.since) auditWhere.timestamp = { gte: filters.since };
+
+  // Fetch 2x limit from each so the merged result has enough entries post-sort
+  const [cjClicks, auditClicks] = await Promise.all([
+    prisma.cjClickEvent.findMany({
+      where: cjWhere,
+      orderBy: { createdAt: "desc" },
+      take: limit * 2,
+      select: {
+        id: true,
+        linkId: true,
+        pageUrl: true,
+        sessionId: true,
+        device: true,
+        country: true,
+        createdAt: true,
+      },
+    }),
+    prisma.auditLog.findMany({
+      where: auditWhere,
+      orderBy: { timestamp: "desc" },
+      take: limit * 2,
+      select: {
+        id: true,
+        details: true,
+        timestamp: true,
+      },
+    }),
+  ]);
+
+  const linkIds = [...new Set<string>(cjClicks.map((c) => c.linkId))];
+  const links = linkIds.length
+    ? await prisma.cjLink.findMany({
+        where: { id: { in: linkIds } },
+        select: { id: true, advertiserName: true, advertiser: { select: { name: true } } },
+      })
+    : [];
+  const linkPartner = new Map(links.map((l) => [l.id, l.advertiserName || l.advertiser?.name || "CJ (unknown)"]));
+
+  const cjFeed: ClickFeedItem[] = cjClicks.map((c) => ({
+    id: c.id,
+    source: "cj" as const,
+    partner: linkPartner.get(c.linkId) || "CJ (unknown)",
+    articleSlug: parseSlugFromSession(c.sessionId),
+    pageUrl: c.pageUrl,
+    device: c.device ?? null,
+    country: c.country ?? null,
+    timestamp: c.createdAt,
+    sessionId: c.sessionId,
+  }));
+
+  const directFeed: ClickFeedItem[] = auditClicks.map((a) => {
+    const d = (a.details ?? {}) as Record<string, unknown>;
+    return {
+      id: a.id,
+      source: "direct" as const,
+      partner: typeof d.partner === "string" ? d.partner : "direct (unknown)",
+      articleSlug: parseSlugFromSession(d.sessionId),
+      pageUrl: typeof d.pageUrl === "string" ? d.pageUrl : null,
+      device: typeof d.device === "string" ? d.device : null,
+      country: typeof d.country === "string" ? d.country : null,
+      timestamp: a.timestamp,
+      sessionId: typeof d.sessionId === "string" ? d.sessionId : null,
+    };
+  });
+
+  return [...cjFeed, ...directFeed].sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime()).slice(0, limit);
+}

--- a/yalla_london/app/lib/affiliate/monitor.ts
+++ b/yalla_london/app/lib/affiliate/monitor.ts
@@ -7,6 +7,8 @@
 
 import { CJ_NETWORK_ID } from "./cj-client";
 import { getDefaultSiteId } from "@/config/sites";
+import { hasAnyAffiliateMarker } from "./partner-detector";
+import { getClickSummary, getClicksByArticle } from "./click-aggregator";
 
 // ---------------------------------------------------------------------------
 // Link Health Monitor
@@ -178,51 +180,49 @@ export async function getRevenueByArticle(siteId?: string): Promise<ArticleReven
 
   const siteFilter = siteId ? { OR: [{ siteId }, { siteId: null }] } : {};
 
-  // Fetch clicks grouped by page URL (which contains article slug)
-  const [clicks7d, clicks30d, commissions] = await Promise.all([
-    prisma.cjClickEvent.findMany({
-      where: { createdAt: { gte: d7 }, ...siteFilter },
-      select: { pageUrl: true, sessionId: true, createdAt: true },
-    }),
-    prisma.cjClickEvent.findMany({
-      where: { createdAt: { gte: d30 }, ...siteFilter },
-      select: { pageUrl: true, sessionId: true, createdAt: true },
-    }),
+  // Unified clicks (CjClickEvent + AuditLog AFFILIATE_CLICK_DIRECT) via aggregator
+  const [clicksByArticle30d, clicksByArticle7d, commissions] = await Promise.all([
+    getClicksByArticle({ siteId, since: d30 }),
+    getClicksByArticle({ siteId, since: d7 }),
     prisma.cjCommission.findMany({
       where: { eventDate: { gte: d30 }, ...siteFilter },
       select: { commissionAmount: true, sid: true, advertiser: { select: { name: true } } },
     }),
   ]);
 
-  // Extract article slug from pageUrl (e.g., "/blog/best-hotels-london" → "best-hotels-london")
-  // or from sessionId (e.g., "yalla-london_best-hotels-london" → "best-hotels-london")
-  const extractSlug = (pageUrl: string | null, sessionId: string | null): string => {
-    if (pageUrl) {
-      const match = pageUrl.match(/\/blog\/([^/?#]+)/);
-      if (match) return match[1];
-    }
-    if (sessionId && sessionId.includes("_")) {
-      return sessionId.split("_").slice(1).join("_");
-    }
-    return "unknown";
-  };
+  // Aggregate clicks by article — start from the 30d map and overlay 7d counts
+  const articleMap = new Map<
+    string,
+    { clicks7d: number; clicks30d: number; revenue: number; lastClick: Date | null; partners: Set<string> }
+  >();
 
-  // Aggregate clicks by article
-  const articleMap = new Map<string, { clicks7d: number; clicks30d: number; revenue: number; lastClick: Date | null; partners: Set<string> }>();
-
-  for (const click of clicks30d) {
-    const slug = extractSlug(click.pageUrl, click.sessionId);
-    if (!articleMap.has(slug)) articleMap.set(slug, { clicks7d: 0, clicks30d: 0, revenue: 0, lastClick: null, partners: new Set() });
-    const entry = articleMap.get(slug)!;
-    entry.clicks30d++;
-    if (click.createdAt >= d7) entry.clicks7d++;
-    if (!entry.lastClick || click.createdAt > entry.lastClick) entry.lastClick = click.createdAt;
+  for (const [slug, count] of clicksByArticle30d.entries()) {
+    articleMap.set(slug, {
+      clicks7d: clicksByArticle7d.get(slug) || 0,
+      clicks30d: count,
+      revenue: 0,
+      lastClick: null,
+      partners: new Set(),
+    });
   }
 
-  for (const click of clicks7d) {
-    const slug = extractSlug(click.pageUrl, click.sessionId);
-    if (!articleMap.has(slug)) articleMap.set(slug, { clicks7d: 0, clicks30d: 0, revenue: 0, lastClick: null, partners: new Set() });
-    // clicks7d already counted in the 30d loop above if within 7d
+  // Populate lastClick from a direct query (aggregator returns counts only)
+  const recentCjClicks = await prisma.cjClickEvent.findMany({
+    where: { createdAt: { gte: d30 }, ...siteFilter },
+    select: { pageUrl: true, sessionId: true, createdAt: true },
+    orderBy: { createdAt: "desc" },
+    take: 2000,
+  });
+  for (const click of recentCjClicks) {
+    const fromUrl = click.pageUrl?.match(/\/blog\/([^/?#]+)/)?.[1];
+    const fromSession =
+      click.sessionId?.includes("_") ? click.sessionId.split("_").slice(1).join("_") : null;
+    const slug = fromUrl || fromSession;
+    if (!slug) continue;
+    const entry = articleMap.get(slug);
+    if (entry && (!entry.lastClick || click.createdAt > entry.lastClick)) {
+      entry.lastClick = click.createdAt;
+    }
   }
 
   // Attribute revenue to articles via SID
@@ -284,20 +284,10 @@ export async function getContentCoverage(siteId?: string): Promise<ContentCovera
     take: 200,
   });
 
-  const hasAffiliate = (content: string) =>
-    content.includes("affiliate-recommendation") ||
-    content.includes("affiliate-cta-block") ||
-    content.includes("affiliate-partners-section") ||
-    content.includes("data-affiliate-partner=") ||
-    content.includes("data-affiliate=") ||
-    content.includes("data-affiliate-id") ||
-    content.includes('rel="sponsored') ||
-    content.includes('rel="noopener sponsored"') ||
-    content.includes("/api/affiliate/click");
+  // Shared affiliate-marker detector (synced with injection cron)
+  const withAffiliates = articles.filter((a) => hasAnyAffiliateMarker(a.content_en));
 
-  const withAffiliates = articles.filter((a) => hasAffiliate(a.content_en || ""));
-
-  const without = articles.filter((a) => !hasAffiliate(a.content_en || ""));
+  const without = articles.filter((a) => !hasAnyAffiliateMarker(a.content_en));
 
   return {
     totalArticles: articles.length,
@@ -339,14 +329,13 @@ export async function getProfitabilityReport(siteId?: string): Promise<Profitabi
   // Include records for this site OR unscoped records (null siteId = legacy data before migration)
   const siteFilter = targetSiteId ? { OR: [{ siteId: targetSiteId }, { siteId: null }] } : {};
 
-  const [commissions, clicks, articleCount, aiCosts] = await Promise.all([
+  const [commissions, clickSummary, articleCount, aiCosts] = await Promise.all([
     prisma.cjCommission.aggregate({
       where: { networkId: CJ_NETWORK_ID, eventDate: { gte: d30 }, ...siteFilter },
       _sum: { commissionAmount: true },
     }),
-    prisma.cjClickEvent.count({
-      where: { createdAt: { gte: d30 }, ...siteFilter },
-    }),
+    // Unified click count (CjClickEvent + AuditLog AFFILIATE_CLICK_DIRECT)
+    getClickSummary({ siteId: targetSiteId, since: d30 }),
     prisma.blogPost.count({
       where: { published: true, deletedAt: null, siteId: targetSiteId },
     }),
@@ -356,6 +345,7 @@ export async function getProfitabilityReport(siteId?: string): Promise<Profitabi
     }),
   ]);
 
+  const clicks = clickSummary.total;
   const totalRevenue = commissions._sum.commissionAmount || 0;
   const aiCost = (aiCosts._sum.estimatedCostUsd || 0);
   const hostingCost = 20; // Vercel Pro $20/month estimate

--- a/yalla_london/app/lib/affiliate/partner-detector.ts
+++ b/yalla_london/app/lib/affiliate/partner-detector.ts
@@ -1,0 +1,70 @@
+/**
+ * Partner Detector + Affiliate Marker Detector
+ *
+ * Shared utilities for:
+ *   - Mapping a partner URL or hostname to a canonical partner name
+ *   - Detecting whether a block of HTML already contains an affiliate link
+ *
+ * Both are used in multiple places: click endpoint, monitor.ts, injection cron,
+ * coverage dashboard. Extracted here so they can never drift apart.
+ */
+
+/**
+ * Map a partner URL or hostname to a canonical partner name.
+ * Used by the click endpoint (for GA4 + AuditLog attribution) and by the
+ * dashboard partner breakdown.
+ */
+export function detectPartner(url: string): string {
+  if (!url) return "unknown";
+  const lower = url.toLowerCase();
+  if (lower.includes("booking.com")) return "booking.com";
+  if (lower.includes("vrbo.com") || lower.includes("anrdoezrs.net")) return "vrbo";
+  if (lower.includes("agoda.com")) return "agoda";
+  if (lower.includes("halalbooking.com")) return "halalbooking";
+  if (lower.includes("getyourguide.com")) return "getyourguide";
+  if (lower.includes("viator.com")) return "viator";
+  if (lower.includes("klook.com")) return "klook";
+  if (lower.includes("hotels.com")) return "hotels.com";
+  if (lower.includes("expedia.com")) return "expedia";
+  if (lower.includes("tripadvisor.com")) return "tripadvisor";
+  if (lower.includes("boatbookings.com")) return "boatbookings";
+  if (lower.includes("welcomepickups.com")) return "welcome-pickups";
+  if (lower.includes("tiqets.com")) return "tiqets";
+  if (lower.includes("ticketnetwork.com")) return "ticketnetwork";
+  if (lower.includes("stay22.com")) return "stay22";
+  if (lower.includes("tp.media") || lower.includes("travelpayouts.com")) return "travelpayouts";
+  return "cj-other";
+}
+
+/**
+ * All known affiliate-link markers that the injection cron (`/api/cron/affiliate-injection`)
+ * can emit into `BlogPost.content_en` or `content_ar`.
+ *
+ * Keep in sync with `app/api/cron/affiliate-injection/route.ts` — any new injection format
+ * MUST add its marker here, or the coverage dashboard and the "needs injection" filter
+ * will silently drift apart.
+ */
+export const AFFILIATE_MARKERS = [
+  'rel="sponsored',
+  'rel="noopener sponsored"',
+  "affiliate-cta-block",
+  "affiliate-recommendation",
+  "affiliate-partners-section",
+  "/api/affiliate/click",
+  "data-affiliate-partner=",
+  "data-affiliate-id",
+  "data-affiliate=",
+] as const;
+
+/**
+ * Returns true if the given HTML contains any affiliate-link marker.
+ * Used by the coverage dashboard (articles WITH affiliates) and the injection
+ * cron's "needs injection" filter (articles WITHOUT affiliates).
+ */
+export function hasAnyAffiliateMarker(html: string | null | undefined): boolean {
+  if (!html) return false;
+  for (const marker of AFFILIATE_MARKERS) {
+    if (html.includes(marker)) return true;
+  }
+  return false;
+}

--- a/yalla_london/app/lib/ceo-engine/intelligence.ts
+++ b/yalla_london/app/lib/ceo-engine/intelligence.ts
@@ -335,17 +335,17 @@ async function fetchIndexingStats(prisma: any, siteId: string) {
 
 async function fetchAffiliateStats(prisma: any, siteId: string, d30: Date) {
   try {
-    const [clicks, commissions] = await Promise.all([
-      prisma.cjClickEvent.count({
-        where: { OR: [{ siteId }, { siteId: null }], createdAt: { gte: d30 } },
-      }),
+    // Unified click count — CjClickEvent (CJ linkId-based) + AuditLog (direct URL)
+    const { getClickSummary } = await import("@/lib/affiliate/click-aggregator");
+    const [clickSummary, commissions] = await Promise.all([
+      getClickSummary({ siteId, since: d30 }),
       prisma.cjCommission.aggregate({
         where: { OR: [{ siteId }, { siteId: null }], createdAt: { gte: d30 } },
         _sum: { commissionAmount: true },
       }),
     ]);
     return {
-      clicks,
+      clicks: clickSummary.total,
       revenue: commissions._sum.commissionAmount ?? 0,
     };
   } catch (err) {

--- a/yalla_london/app/prisma/migrations/20260418_add_audit_log_affiliate_index/migration.sql
+++ b/yalla_london/app/prisma/migrations/20260418_add_audit_log_affiliate_index/migration.sql
@@ -1,0 +1,17 @@
+-- Affiliate click visibility fix: dashboard now unifies CjClickEvent (CJ links)
+-- with AuditLog action=AFFILIATE_CLICK_DIRECT (Travelpayouts/Stay22/Vrbo-fallback
+-- clicks that have no CjLink record).
+--
+-- Without this partial index, the JSONB path filter on details->>'siteId' forces
+-- a sequential scan on the full audit_log table. audit_log grows ~100-500 rows/day
+-- from cron failures and other actions; within a month the dashboard count queries
+-- would take several seconds per refresh.
+
+CREATE INDEX IF NOT EXISTS "audit_log_affiliate_click_direct_idx"
+  ON "audit_log" ((details->>'siteId'), action, timestamp)
+  WHERE action = 'AFFILIATE_CLICK_DIRECT';
+
+-- Also index the action + timestamp pair for cross-site queries (cockpit, reports)
+CREATE INDEX IF NOT EXISTS "audit_log_affiliate_click_timestamp_idx"
+  ON "audit_log" (action, timestamp)
+  WHERE action = 'AFFILIATE_CLICK_DIRECT';

--- a/yalla_london/app/scripts/smoke-test.ts
+++ b/yalla_london/app/scripts/smoke-test.ts
@@ -1769,6 +1769,126 @@ test("SEO Infrastructure", "Privacy and terms pages in sitemap with yearly frequ
     : { status: FAIL, details: `privacy=${privacyFreq}, terms=${termsFreq} — legal pages should be yearly` };
 });
 
+// ==================== CATEGORY: Affiliate Click Visibility ====================
+// Dashboard used to query CjClickEvent only; direct URL clicks (Travelpayouts,
+// Vrbo fallback, static rules) wrote to audit_log with action=AFFILIATE_CLICK_DIRECT
+// and were invisible. These tests prevent the visibility regression from returning.
+
+test("Affiliate Click Visibility", "click-aggregator library exists with unified helpers", () => {
+  const file = "lib/affiliate/click-aggregator.ts";
+  if (!fileExists(file)) return { status: FAIL, details: "lib/affiliate/click-aggregator.ts missing" };
+  const required = ["getClickSummary", "getClicksByArticle", "getClicksByPartner", "getClicksByDay", "getRecentClickFeed"];
+  const missing = required.filter((fn) => !fileContains(file, `export async function ${fn}`));
+  return missing.length === 0
+    ? { status: PASS, details: `All 5 aggregator helpers exported` }
+    : { status: FAIL, details: `Missing: ${missing.join(", ")}` };
+});
+
+test("Affiliate Click Visibility", "partner-detector exports shared hasAnyAffiliateMarker + AFFILIATE_MARKERS", () => {
+  const file = "lib/affiliate/partner-detector.ts";
+  if (!fileExists(file)) return { status: FAIL, details: "lib/affiliate/partner-detector.ts missing" };
+  const hasMarker = fileContains(file, "export function hasAnyAffiliateMarker");
+  const hasList = fileContains(file, "export const AFFILIATE_MARKERS");
+  const hasPartner = fileContains(file, "export function detectPartner");
+  return hasMarker && hasList && hasPartner
+    ? { status: PASS, details: "detectPartner, hasAnyAffiliateMarker, AFFILIATE_MARKERS all exported" }
+    : { status: FAIL, details: `missing exports: marker=${hasMarker} list=${hasList} partner=${hasPartner}` };
+});
+
+test("Affiliate Click Visibility", "affiliate-hq queries auditLog with correct AFFILIATE_CLICK_DIRECT action name", () => {
+  const file = "app/api/admin/affiliate-hq/route.ts";
+  if (!fileExists(file)) return { status: FAIL, details: "affiliate-hq route missing" };
+  const usesAggregator = fileContains(file, "getClickSummary") && fileContains(file, "getClicksByDay");
+  const hasBadActionName = fileContains(file, 'action: "affiliate_click"');
+  if (hasBadActionName) return { status: FAIL, details: "Still uses wrong action 'affiliate_click' — should be 'AFFILIATE_CLICK_DIRECT'" };
+  return usesAggregator
+    ? { status: PASS, details: "affiliate-hq delegates click counting to aggregator" }
+    : { status: FAIL, details: "affiliate-hq does not import click-aggregator" };
+});
+
+test("Affiliate Click Visibility", "affiliate-hq coverage uses shared hasAnyAffiliateMarker (not local 4-pattern array)", () => {
+  const file = "app/api/admin/affiliate-hq/route.ts";
+  if (!fileExists(file)) return { status: FAIL, details: "affiliate-hq route missing" };
+  const usesHelper = fileContains(file, "hasAnyAffiliateMarker");
+  const hasOldNarrowList = fileContains(
+    file,
+    `const affiliatePatterns = ['rel="sponsored', "affiliate-cta-block", "affiliate-recommendation"`,
+  );
+  if (hasOldNarrowList) return { status: FAIL, details: "Old 4-pattern affiliatePatterns array still present" };
+  return usesHelper
+    ? { status: PASS, details: "affiliate-hq uses shared marker detector" }
+    : { status: FAIL, details: "affiliate-hq does not import hasAnyAffiliateMarker" };
+});
+
+test("Affiliate Click Visibility", "affiliate-monitor counts BOTH CjClickEvent and AuditLog AFFILIATE_CLICK_DIRECT", () => {
+  const file = "app/api/admin/affiliate-monitor/route.ts";
+  if (!fileExists(file)) return { status: FAIL, details: "affiliate-monitor route missing" };
+  const countsCj = fileContains(file, "cjClickEvent.count");
+  const countsAudit = fileContains(file, 'action: "AFFILIATE_CLICK_DIRECT"');
+  return countsCj && countsAudit
+    ? { status: PASS, details: "Counts both CJ and direct URL clicks" }
+    : { status: FAIL, details: `CJ=${countsCj} AuditLog=${countsAudit}` };
+});
+
+test("Affiliate Click Visibility", "aggregated-report Section 9 uses getClickSummary", () => {
+  const file = "app/api/admin/aggregated-report/route.ts";
+  if (!fileExists(file)) return { status: FAIL, details: "aggregated-report route missing" };
+  return fileContains(file, "getClickSummary")
+    ? { status: PASS, details: "aggregated-report imports click-aggregator" }
+    : { status: FAIL, details: "aggregated-report still uses cjClickEvent.count directly" };
+});
+
+test("Affiliate Click Visibility", "cockpit buildRevenue raw SQL counts AFFILIATE_CLICK_DIRECT", () => {
+  const file = "app/api/admin/cockpit/route.ts";
+  if (!fileExists(file)) return { status: FAIL, details: "cockpit route missing" };
+  return fileContains(file, "AFFILIATE_CLICK_DIRECT")
+    ? { status: PASS, details: "cockpit includes audit_log direct clicks in revenue snapshot" }
+    : { status: FAIL, details: "cockpit buildRevenue missing direct click count" };
+});
+
+test("Affiliate Click Visibility", "ceo-engine fetchAffiliateStats uses aggregator", () => {
+  const file = "lib/ceo-engine/intelligence.ts";
+  if (!fileExists(file)) return { status: FAIL, details: "ceo-engine intelligence.ts missing" };
+  return fileContains(file, "getClickSummary")
+    ? { status: PASS, details: "ceo-engine uses click-aggregator" }
+    : { status: FAIL, details: "ceo-engine still queries cjClickEvent directly" };
+});
+
+test("Affiliate Click Visibility", "JSONB index migration for audit_log direct clicks exists", () => {
+  const file = "prisma/migrations/20260418_add_audit_log_affiliate_index/migration.sql";
+  if (!fileExists(file)) return { status: FAIL, details: "JSONB index migration missing" };
+  const hasIndex = fileContains(file, "audit_log_affiliate_click_direct_idx");
+  const isPartial = fileContains(file, "WHERE action = 'AFFILIATE_CLICK_DIRECT'");
+  return hasIndex && isPartial
+    ? { status: PASS, details: "Partial JSONB index on audit_log for AFFILIATE_CLICK_DIRECT" }
+    : { status: FAIL, details: `index=${hasIndex} partial=${isPartial}` };
+});
+
+test("Affiliate Click Visibility", "injection cron + aggregator + dashboards all agree on marker list", () => {
+  // The injection cron defines "needs injection" as the absence of these markers.
+  // If partner-detector.ts and the injection filter drift apart, coverage and
+  // re-injection loops break silently.
+  const injectionFile = "app/api/cron/affiliate-injection/route.ts";
+  const detectorFile = "lib/affiliate/partner-detector.ts";
+  if (!fileExists(injectionFile) || !fileExists(detectorFile))
+    return { status: FAIL, details: "Injection route or partner-detector missing" };
+  // Every marker in AFFILIATE_MARKERS must appear in the injection filter block.
+  const markers = [
+    'rel="sponsored',
+    'rel="noopener sponsored"',
+    "affiliate-cta-block",
+    "affiliate-recommendation",
+    "affiliate-partners-section",
+    "/api/affiliate/click",
+    "data-affiliate-partner=",
+    "data-affiliate-id",
+  ];
+  const missing = markers.filter((m) => !fileContains(injectionFile, m));
+  return missing.length === 0
+    ? { status: PASS, details: "All affiliate markers present in injection cron filter" }
+    : { status: FAIL, details: `Injection filter missing: ${missing.join(", ")}` };
+});
+
 // Compute categories AFTER all tests have run
 const categories = [...new Set(results.map(r => r.category))];
 let totalPass = 0, totalFail = 0, totalWarn = 0;


### PR DESCRIPTION
Root cause of zero dashboard clicks: every server-injected affiliate link is
wrapped through /api/affiliate/click, but direct URL clicks (Travelpayouts,
Vrbo fallback, Welcome Pickups, Tiqets, TicketNetwork, static rules) hit Path 1
of the endpoint and write to AuditLog with action=AFFILIATE_CLICK_DIRECT —
CjClickEvent.linkId is a required FK, so those rows cannot live there.

Every dashboard queried CjClickEvent only, so all direct URL clicks were
invisible. affiliate-hq also had action name bug ('affiliate_click' vs actual
'AFFILIATE_CLICK_DIRECT') that silently returned 0 for a month.

Fixes:
- New lib/affiliate/click-aggregator.ts — unified getClickSummary, getClicksByArticle,
  getClicksByPartner, getClicksByDay, getRecentClickFeed helpers that merge both
  sources in parallel queries.
- New lib/affiliate/partner-detector.ts — shared detectPartner, hasAnyAffiliateMarker,
  AFFILIATE_MARKERS list. Keeps injection cron filter and coverage dashboards in sync.
- affiliate-hq/route.ts: fix action name, swap click queries to aggregator, include
  direct clicks in clicks7d/clicksByDay/topArticlesByClicks/per-page counts, replace
  4-pattern narrow array with shared hasAnyAffiliateMarker.
- affiliate-monitor/route.ts: partner breakdown + recent feed now use aggregator;
  added attribution diagnostic ("clicks are all direct URLs, revenue lives in TP/Stay22").
- aggregated-report/route.ts Section 9: clicks7d via aggregator, coverage uses
  AFFILIATE_MARKERS list.
- cockpit/route.ts buildRevenue: raw SQL now counts audit_log AFFILIATE_CLICK_DIRECT
  alongside cj_click_events and affiliate_clicks.
- ceo-engine/intelligence.ts fetchAffiliateStats: uses aggregator.
- lib/affiliate/monitor.ts: getProfitabilityReport + getRevenueByArticle use aggregator;
  getContentCoverage delegates to shared hasAnyAffiliateMarker.
- New migration 20260418_add_audit_log_affiliate_index: partial JSONB index on
  audit_log (details->>'siteId', action, timestamp) filtered to AFFILIATE_CLICK_DIRECT.
- scripts/smoke-test.ts: 10 new Affiliate Click Visibility tests prevent regression.

Verification: 0 TypeScript errors, 10/10 new tests pass, existing 200 tests unchanged.
Post-deploy: cockpit Revenue card + affiliate-hq Revenue tab should surface the
accumulated clicks hidden in audit_log since March 10.

https://claude.ai/code/session_01LgruxSsmMYL25UwLSwhJxs