### PR TITLE
fix(crons): daily-seo-audit 401 + diagnostic-agent AI cascade classification

### DIFF
--- a/yalla_london/app/app/api/admin/seo-audit/route.ts
+++ b/yalla_london/app/app/api/admin/seo-audit/route.ts
@@ -37,7 +37,7 @@ interface AuditSection {
   findings: AuditFinding[];
 }
 
-async function runAudit(siteId: string) {
+export async function runAudit(siteId: string) {
   const auditStart = Date.now();
   const BUDGET_MS = 53_000;
 

--- a/yalla_london/app/app/api/cron/daily-seo-audit/route.ts
+++ b/yalla_london/app/app/api/cron/daily-seo-audit/route.ts
@@ -53,34 +53,33 @@ async function handleDailySeoAudit(request: NextRequest) {
     }
 
     try {
-      // Call the audit endpoint internally (reuse existing runAudit logic)
-      const baseUrl = request.nextUrl.origin;
-      const auditUrl = `${baseUrl}/api/admin/seo-audit?siteId=${encodeURIComponent(siteId)}&triggeredBy=scheduled`;
+      // Direct function call — avoids cross-function HTTP auth race conditions
+      // (rule #100: never internal-fetch from a cron to itself).
+      const { runAudit } = await import("@/app/api/admin/seo-audit/route");
+      const auditData = (await runAudit(siteId)) as unknown as Record<string, unknown>;
 
-      const headers: Record<string, string> = {};
-      // Forward admin auth if present
-      const adminCookie = request.headers.get("cookie");
-      if (adminCookie) headers["cookie"] = adminCookie;
-      // For internal calls, use the admin-bypass header if cron secret is available
-      if (cronSecret) headers["authorization"] = `Bearer ${cronSecret}`;
-
-      const resp = await fetch(auditUrl, {
-        headers,
-        signal: AbortSignal.timeout(45_000),
-      });
-
-      if (!resp.ok) {
-        results.push({ siteId, healthScore: 0, findings: 0, critical: 0, high: 0, saved: false, error: `HTTP ${resp.status}` });
-        continue;
+      // Persist to SeoAuditReport (mirrors what the GET handler does on direct calls)
+      try {
+        await prisma.seoAuditReport.create({
+          data: {
+            siteId,
+            healthScore: (auditData.healthScore as number) || 0,
+            totalFindings: (auditData.totalFindings as number) || 0,
+            criticalCount: (auditData.criticalCount as number) || 0,
+            highCount: (auditData.highCount as number) || 0,
+            mediumCount: (auditData.mediumCount as number) || 0,
+            lowCount: (auditData.lowCount as number) || 0,
+            report: auditData,
+            summary: auditData.summary as string,
+            triggeredBy: "scheduled",
+          },
+        });
+      } catch (createErr) {
+        console.warn(`[daily-seo-audit] Failed to persist report for ${siteId}:`, createErr instanceof Error ? createErr.message : createErr);
       }
 
-      const auditData = await resp.json();
-
-      // The GET endpoint auto-persists to SeoAuditReport, so it's already saved.
-      // Generate and save the action-oriented JSON summary separately.
+      // Generate and attach the compact action-oriented JSON summary.
       const jsonSummary = buildActionSummary(auditData, siteId, getSiteConfig(siteId), getSiteDomain(siteId));
-
-      // Update the most recent report with the JSON summary
       try {
         const latestReport = await prisma.seoAuditReport.findFirst({
           where: { siteId },
@@ -107,10 +106,10 @@ async function handleDailySeoAudit(request: NextRequest) {
 
       results.push({
         siteId,
-        healthScore: auditData.healthScore || 0,
-        findings: auditData.totalFindings || 0,
-        critical: auditData.criticalCount || 0,
-        high: auditData.highCount || 0,
+        healthScore: (auditData.healthScore as number) || 0,
+        findings: (auditData.totalFindings as number) || 0,
+        critical: (auditData.criticalCount as number) || 0,
+        high: (auditData.highCount as number) || 0,
         saved: true,
       });
     } catch (err) {

--- a/yalla_london/app/lib/ops/diagnostic-agent.ts
+++ b/yalla_london/app/lib/ops/diagnostic-agent.ts
@@ -234,6 +234,18 @@ export async function diagnoseFailedCrons(): Promise<Diagnosis[]> {
         category = "database_unavailable";
       } else if (combinedMsg.includes("no consumable topic") || combinedMsg.includes("no topic") || combinedMsg.includes("topic pool") || combinedMsg.includes("nothing to process")) {
         category = "topic_starvation";
+      } else if (
+        // AI cascade patterns (must come BEFORE generic timeout/api checks):
+        // - "All AI providers failed: grok: ... timeout; claude: ... timeout"
+        // - "N/N articles failed to generate" (daily-content-generate top-level error)
+        // - "X failed to generate" or "AI generation"
+        combinedMsg.includes("all ai providers failed") ||
+        combinedMsg.includes("articles failed to generate") ||
+        combinedMsg.includes("ai generation") ||
+        combinedMsg.includes("circuit open") ||
+        combinedMsg.includes("circuit breaker")
+      ) {
+        category = "provider_down";
       } else if (errorMsg.includes("timeout") || errorMsg.includes("aborted")) {
         category = "timeout";
       } else if (errorMsg.includes("api") || errorMsg.includes("429") || errorMsg.includes("503")) {


### PR DESCRIPTION
Two surgical fixes from 24h ops log audit:

1. daily-seo-audit HTTP 401 for zenitha-yachts-med
   - Replaced internal HTTP self-fetch with direct runAudit() function call
   - Eliminates cross-function auth race conditions and Vercel cold-start
     401s when looping multiple sites
   - Pattern matches CLAUDE.md rule #100 (never internal-fetch from a cron
     to itself); same pattern as lib/affiliate/cj-sync.ts
   - Exported runAudit from app/api/admin/seo-audit/route.ts
   - Persists report directly via prisma.seoAuditReport.create

2. diagnostic-agent classifying daily-content-generate AI failures as "unknown"
   - Top-level cron error "2/2 articles failed to generate" + AI call error
     "All AI providers failed: grok: ... timeout; claude: ... timeout"
     fell through error chain → category=unknown → CEO Inbox alert with
     no useful context
   - Added pattern matchers BEFORE generic timeout/api checks for:
     "all ai providers failed", "articles failed to generate",
     "ai generation", "circuit open", "circuit breaker"
   - Now classified as provider_down → CEO Inbox can route to "Check AI
     Config tab" guidance

Verified with npx tsc --noEmit (zero errors).

https://claude.ai/code/session_015wB9mPzjhzWZWzKTQJKLAe