### PR TITLE
fix(aggregated-report): surface specific articles + cron error messages

### DIFF
--- a/.claude/logs/sessions/2026-04-27_04-43.md
+++ b/.claude/logs/sessions/2026-04-27_04-43.md
@@ -1,0 +1,9 @@
+# Session Log: 2026-04-27_04-43
+- **Session ID:** be055df3-bce6-436f-89eb-e9289748556f
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 0
+
+## Changes
+```
+
+```

--- a/.claude/logs/sessions/2026-04-27_04-57.md
+++ b/.claude/logs/sessions/2026-04-27_04-57.md
@@ -1,10 +1,9 @@
 # Session Log: 2026-04-27_04-57
 - **Session ID:** be055df3-bce6-436f-89eb-e9289748556f
 - **Branch:** claude/fix-yalla-london-seo-lzFxF
-- **Uncommitted changes:** 2
+- **Uncommitted changes:** 0
 
 ## Changes
 ```
- PROJECT_STATUS.md | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+
 ```

--- a/.claude/logs/sessions/2026-04-27_04-57.md
+++ b/.claude/logs/sessions/2026-04-27_04-57.md
@@ -1,0 +1,10 @@
+# Session Log: 2026-04-27_04-57
+- **Session ID:** be055df3-bce6-436f-89eb-e9289748556f
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ PROJECT_STATUS.md | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+```

--- a/.claude/logs/sessions/2026-04-27_05-36.md
+++ b/.claude/logs/sessions/2026-04-27_05-36.md
@@ -1,0 +1,11 @@
+# Session Log: 2026-04-27_05-36
+- **Session ID:** f41eb8cf-f55b-4038-a349-f91107b5cc0e
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ .claude/logs/sessions/2026-04-27_04-57.md | 5 ++---
+ PROJECT_STATUS.md                         | 2 +-
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+```

--- a/.claude/logs/sessions/2026-04-27_05-36.md
+++ b/.claude/logs/sessions/2026-04-27_05-36.md
@@ -1,11 +1,9 @@
 # Session Log: 2026-04-27_05-36
 - **Session ID:** f41eb8cf-f55b-4038-a349-f91107b5cc0e
 - **Branch:** claude/fix-yalla-london-seo-lzFxF
-- **Uncommitted changes:** 2
+- **Uncommitted changes:** 0
 
 ## Changes
 ```
- .claude/logs/sessions/2026-04-27_04-57.md | 5 ++---
- PROJECT_STATUS.md                         | 2 +-
- 2 files changed, 3 insertions(+), 4 deletions(-)
+
 ```

--- a/.claude/logs/sessions/2026-04-27_05-40.md
+++ b/.claude/logs/sessions/2026-04-27_05-40.md
@@ -1,0 +1,11 @@
+# Session Log: 2026-04-27_05-40
+- **Session ID:** f41eb8cf-f55b-4038-a349-f91107b5cc0e
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ .claude/logs/sessions/2026-04-27_05-36.md | 6 ++----
+ PROJECT_STATUS.md                         | 2 +-
+ 2 files changed, 3 insertions(+), 5 deletions(-)
+```

--- a/.claude/logs/sessions/2026-04-27_05-40.md
+++ b/.claude/logs/sessions/2026-04-27_05-40.md
@@ -1,11 +1,9 @@
 # Session Log: 2026-04-27_05-40
 - **Session ID:** f41eb8cf-f55b-4038-a349-f91107b5cc0e
 - **Branch:** claude/fix-yalla-london-seo-lzFxF
-- **Uncommitted changes:** 2
+- **Uncommitted changes:** 0
 
 ## Changes
 ```
- .claude/logs/sessions/2026-04-27_05-36.md | 6 ++----
- PROJECT_STATUS.md                         | 2 +-
- 2 files changed, 3 insertions(+), 5 deletions(-)
+
 ```

--- a/.claude/logs/sessions/2026-04-27_05-47.md
+++ b/.claude/logs/sessions/2026-04-27_05-47.md
@@ -1,11 +1,9 @@
 # Session Log: 2026-04-27_05-47
 - **Session ID:** f41eb8cf-f55b-4038-a349-f91107b5cc0e
 - **Branch:** claude/fix-yalla-london-seo-lzFxF
-- **Uncommitted changes:** 2
+- **Uncommitted changes:** 0
 
 ## Changes
 ```
- .claude/logs/sessions/2026-04-27_05-40.md | 6 ++----
- PROJECT_STATUS.md                         | 2 +-
- 2 files changed, 3 insertions(+), 5 deletions(-)
+
 ```

--- a/.claude/logs/sessions/2026-04-27_05-47.md
+++ b/.claude/logs/sessions/2026-04-27_05-47.md
@@ -1,0 +1,11 @@
+# Session Log: 2026-04-27_05-47
+- **Session ID:** f41eb8cf-f55b-4038-a349-f91107b5cc0e
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ .claude/logs/sessions/2026-04-27_05-40.md | 6 ++----
+ PROJECT_STATUS.md                         | 2 +-
+ 2 files changed, 3 insertions(+), 5 deletions(-)
+```

--- a/.claude/logs/sessions/2026-04-27_05-54.md
+++ b/.claude/logs/sessions/2026-04-27_05-54.md
@@ -1,0 +1,11 @@
+# Session Log: 2026-04-27_05-54
+- **Session ID:** f41eb8cf-f55b-4038-a349-f91107b5cc0e
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ .claude/logs/sessions/2026-04-27_05-47.md | 6 ++----
+ PROJECT_STATUS.md                         | 2 +-
+ 2 files changed, 3 insertions(+), 5 deletions(-)
+```

--- a/.claude/logs/sessions/2026-04-27_05-54.md
+++ b/.claude/logs/sessions/2026-04-27_05-54.md
@@ -1,11 +1,9 @@
 # Session Log: 2026-04-27_05-54
 - **Session ID:** f41eb8cf-f55b-4038-a349-f91107b5cc0e
 - **Branch:** claude/fix-yalla-london-seo-lzFxF
-- **Uncommitted changes:** 2
+- **Uncommitted changes:** 0
 
 ## Changes
 ```
- .claude/logs/sessions/2026-04-27_05-47.md | 6 ++----
- PROJECT_STATUS.md                         | 2 +-
- 2 files changed, 3 insertions(+), 5 deletions(-)
+
 ```

--- a/.claude/logs/sessions/2026-04-27_06-02.md
+++ b/.claude/logs/sessions/2026-04-27_06-02.md
@@ -1,0 +1,11 @@
+# Session Log: 2026-04-27_06-02
+- **Session ID:** f41eb8cf-f55b-4038-a349-f91107b5cc0e
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ .claude/logs/sessions/2026-04-27_05-54.md | 6 ++----
+ PROJECT_STATUS.md                         | 2 +-
+ 2 files changed, 3 insertions(+), 5 deletions(-)
+```

--- a/.claude/logs/sessions/2026-04-27_06-02.md
+++ b/.claude/logs/sessions/2026-04-27_06-02.md
@@ -1,11 +1,9 @@
 # Session Log: 2026-04-27_06-02
 - **Session ID:** f41eb8cf-f55b-4038-a349-f91107b5cc0e
 - **Branch:** claude/fix-yalla-london-seo-lzFxF
-- **Uncommitted changes:** 2
+- **Uncommitted changes:** 0
 
 ## Changes
 ```
- .claude/logs/sessions/2026-04-27_05-54.md | 6 ++----
- PROJECT_STATUS.md                         | 2 +-
- 2 files changed, 3 insertions(+), 5 deletions(-)
+
 ```

--- a/.claude/logs/sessions/2026-04-27_06-11.md
+++ b/.claude/logs/sessions/2026-04-27_06-11.md
@@ -1,0 +1,11 @@
+# Session Log: 2026-04-27_06-11
+- **Session ID:** 9132d006-d926-4e10-85a8-7da02aff4eb4
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ .claude/logs/sessions/2026-04-27_06-02.md | 6 ++----
+ PROJECT_STATUS.md                         | 2 +-
+ 2 files changed, 3 insertions(+), 5 deletions(-)
+```

--- a/.claude/logs/sessions/2026-04-27_06-12.md
+++ b/.claude/logs/sessions/2026-04-27_06-12.md
@@ -1,0 +1,9 @@
+# Session Log: 2026-04-27_06-12
+- **Session ID:** 9132d006-d926-4e10-85a8-7da02aff4eb4
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 0
+
+## Changes
+```
+
+```

--- a/.claude/logs/sessions/2026-04-27_06-17.md
+++ b/.claude/logs/sessions/2026-04-27_06-17.md
@@ -1,0 +1,10 @@
+# Session Log: 2026-04-27_06-17
+- **Session ID:** 9132d006-d926-4e10-85a8-7da02aff4eb4
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ PROJECT_STATUS.md | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+```

--- a/.claude/logs/sessions/2026-04-27_06-18.md
+++ b/.claude/logs/sessions/2026-04-27_06-18.md
@@ -1,0 +1,9 @@
+# Session Log: 2026-04-27_06-18
+- **Session ID:** 9132d006-d926-4e10-85a8-7da02aff4eb4
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 0
+
+## Changes
+```
+
+```

--- a/.claude/logs/sessions/2026-04-27_06-31.md
+++ b/.claude/logs/sessions/2026-04-27_06-31.md
@@ -1,0 +1,10 @@
+# Session Log: 2026-04-27_06-31
+- **Session ID:** 9132d006-d926-4e10-85a8-7da02aff4eb4
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ PROJECT_STATUS.md | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+```

--- a/.claude/logs/sessions/2026-04-27_06-31.md
+++ b/.claude/logs/sessions/2026-04-27_06-31.md
@@ -1,10 +1,9 @@
 # Session Log: 2026-04-27_06-31
 - **Session ID:** 9132d006-d926-4e10-85a8-7da02aff4eb4
 - **Branch:** claude/fix-yalla-london-seo-lzFxF
-- **Uncommitted changes:** 2
+- **Uncommitted changes:** 0
 
 ## Changes
 ```
- PROJECT_STATUS.md | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+
 ```

--- a/.claude/logs/sessions/2026-04-27_10-16.md
+++ b/.claude/logs/sessions/2026-04-27_10-16.md
@@ -1,11 +1,9 @@
 # Session Log: 2026-04-27_10-16
 - **Session ID:** 42af852d-e32b-4eee-90ce-0bdb1f09e2a8
 - **Branch:** claude/fix-yalla-london-seo-lzFxF
-- **Uncommitted changes:** 2
+- **Uncommitted changes:** 0
 
 ## Changes
 ```
- .claude/logs/sessions/2026-04-27_06-31.md | 5 ++---
- PROJECT_STATUS.md                         | 2 +-
- 2 files changed, 3 insertions(+), 4 deletions(-)
+
 ```

--- a/.claude/logs/sessions/2026-04-27_10-16.md
+++ b/.claude/logs/sessions/2026-04-27_10-16.md
@@ -1,0 +1,11 @@
+# Session Log: 2026-04-27_10-16
+- **Session ID:** 42af852d-e32b-4eee-90ce-0bdb1f09e2a8
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ .claude/logs/sessions/2026-04-27_06-31.md | 5 ++---
+ PROJECT_STATUS.md                         | 2 +-
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+```

--- a/.claude/logs/sessions/2026-04-27_10-58.md
+++ b/.claude/logs/sessions/2026-04-27_10-58.md
@@ -1,0 +1,11 @@
+# Session Log: 2026-04-27_10-58
+- **Session ID:** e0e86936-e63a-4d7c-874a-709518ce6c85
+- **Branch:** claude/fix-yalla-london-seo-lzFxF
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ .claude/logs/sessions/2026-04-27_10-16.md | 6 ++----
+ PROJECT_STATUS.md                         | 2 +-
+ 2 files changed, 3 insertions(+), 5 deletions(-)
+```

--- a/.mcp.json
+++ b/.mcp.json
@@ -13,7 +13,12 @@
     "platform-control": {
       "command": "npx",
       "args": ["tsx", "yalla_london/app/scripts/mcp-platform-server.ts"],
-      "env": {}
+      "env": {
+        "DATABASE_URL": "${DATABASE_URL}",
+        "DIRECT_URL": "${DIRECT_URL}",
+        "CRON_SECRET": "${CRON_SECRET}",
+        "DEFAULT_SITE_ID": "${DEFAULT_SITE_ID}"
+      }
     }
   }
 }

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,10 +2,10 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-25 08:18 UTC
+- Date: 2026-04-27 04:57 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
-- Files changed: 0 files
+- Files changed: 2 files
 
 ## Active Branches
 | Branch | Purpose | Status |

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-27 10:16 UTC
+- Date: 2026-04-27 10:58 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-27 06:11 UTC
+- Date: 2026-04-27 06:17 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-27 05:40 UTC
+- Date: 2026-04-27 05:47 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-27 04:57 UTC
+- Date: 2026-04-27 05:36 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-27 05:54 UTC
+- Date: 2026-04-27 06:02 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-27 05:36 UTC
+- Date: 2026-04-27 05:40 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-27 06:17 UTC
+- Date: 2026-04-27 06:31 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-27 05:47 UTC
+- Date: 2026-04-27 05:54 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-27 06:31 UTC
+- Date: 2026-04-27 10:16 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-04-27 06:02 UTC
+- Date: 2026-04-27 06:11 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/yalla_london/app/app/api/admin/aggregated-report/route.ts
+++ b/yalla_london/app/app/api/admin/aggregated-report/route.ts
@@ -130,7 +130,7 @@ export async function GET(request: NextRequest) {
     let latestAudit: Record<string, unknown> | null = null;
     let auditScore = 0;
     let auditSummary = "";
-    let auditFindings: Array<{ id: string; severity: string; category: string; title: string; fix: string; count: number }> = [];
+    let auditFindings: Array<{ id: string; severity: string; category: string; title: string; fix: string; count: number; affected?: string[] }> = [];
     try {
       const report = await prisma.seoAuditReport.findFirst({
         where: { siteId },
@@ -140,7 +140,7 @@ export async function GET(request: NextRequest) {
         latestAudit = report.report as Record<string, unknown>;
         auditScore = report.healthScore;
         auditSummary = report.summary || "";
-        auditFindings = ((latestAudit?.findings || []) as Array<{ id: string; severity: string; category: string; title: string; fix: string; count: number }>);
+        auditFindings = ((latestAudit?.findings || []) as Array<{ id: string; severity: string; category: string; title: string; fix: string; count: number; affected?: string[] }>);
       }
     } catch (e) { console.warn("[aggregated-report] audit fetch:", e instanceof Error ? e.message : e); }
 
@@ -262,20 +262,33 @@ export async function GET(request: NextRequest) {
     // ═══════════════════════════════════════════════════════════════════════
     // 5. OPERATIONAL HEALTH (cron jobs, AI costs)
     // ═══════════════════════════════════════════════════════════════════════
-    let operations = { cronFailures24h: 0, cronSuccesses24h: 0, failedCrons: [] as string[], aiCost7d: 0, aiCalls7d: 0, aiFailures7d: 0, autoFixes7d: 0 };
+    let operations = { cronFailures24h: 0, cronSuccesses24h: 0, failedCrons: [] as string[], failedCronDetails: [] as Array<{ name: string; error: string; lastFailedAt: string }>, aiCost7d: 0, aiCalls7d: 0, aiFailures7d: 0, autoFixes7d: 0 };
     if (Date.now() - start < BUDGET_MS - 5_000) {
       try {
         const d24h = new Date(Date.now() - 86400000);
         const d7 = new Date(Date.now() - 7 * 86400000);
 
         const cronSiteFilter = siteId ? { OR: [{ site_id: siteId }, { site_id: null }] } : {};
-        const [cronFail, cronOk, failedNames, aiAgg, autoFixCount] = await Promise.all([
+        const [cronFail, cronOk, failedRecent, aiAgg, autoFixCount] = await Promise.all([
           prisma.cronJobLog.count({ where: { status: "failed", started_at: { gte: d24h }, ...cronSiteFilter } }),
           prisma.cronJobLog.count({ where: { status: "completed", started_at: { gte: d24h }, ...cronSiteFilter } }),
-          prisma.cronJobLog.findMany({ where: { status: "failed", started_at: { gte: d24h }, ...cronSiteFilter }, select: { job_name: true }, distinct: ["job_name"] }),
+          prisma.cronJobLog.findMany({ where: { status: "failed", started_at: { gte: d24h }, ...cronSiteFilter }, select: { job_name: true, error_message: true, started_at: true }, orderBy: { started_at: "desc" }, take: 100 }),
           prisma.apiUsageLog.aggregate({ _sum: { estimatedCostUsd: true, totalTokens: true }, _count: { id: true }, where: { siteId, createdAt: { gte: d7 } } }).catch(() => ({ _sum: { estimatedCostUsd: null, totalTokens: null }, _count: { id: 0 } })),
           prisma.autoFixLog.count({ where: { createdAt: { gte: d7 } } }).catch(() => 0),
         ]);
+
+        // De-dup by job_name keeping the latest failure (failedRecent is already ordered desc)
+        const seenCrons = new Set<string>();
+        const failedCronDetails: Array<{ name: string; error: string; lastFailedAt: string }> = [];
+        for (const f of failedRecent) {
+          if (seenCrons.has(f.job_name)) continue;
+          seenCrons.add(f.job_name);
+          failedCronDetails.push({
+            name: f.job_name,
+            error: (f.error_message || "(no error message captured)").slice(0, 280),
+            lastFailedAt: f.started_at.toISOString(),
+          });
+        }
 
         let aiFailures = 0;
         try {
@@ -284,7 +297,8 @@ export async function GET(request: NextRequest) {
 
         operations = {
           cronFailures24h: cronFail, cronSuccesses24h: cronOk,
-          failedCrons: failedNames.map((f) => f.job_name),
+          failedCrons: failedCronDetails.map((f) => f.name),
+          failedCronDetails,
           aiCost7d: Math.round((aiAgg._sum.estimatedCostUsd || 0) * 100) / 100,
           aiCalls7d: aiAgg._count.id || 0,
           aiFailures7d: aiFailures,
@@ -450,7 +464,7 @@ export async function GET(request: NextRequest) {
     // ═══════════════════════════════════════════════════════════════════════
     // 9. SYNTHESIZE: Issues + Root Causes + Fix Plan
     // ═══════════════════════════════════════════════════════════════════════
-    const issues: Array<{ severity: string; category: string; title: string; rootCause: string; fix: string }> = [];
+    const issues: Array<{ severity: string; category: string; title: string; rootCause: string; fix: string; affected?: string[] }> = [];
 
     // From audit findings
     for (const f of auditFindings.filter((f) => f.severity === "critical" || f.severity === "high")) {
@@ -460,16 +474,21 @@ export async function GET(request: NextRequest) {
         title: f.title,
         rootCause: diagnoseRootCause(f.id, f.category, pipeline, operations, indexing),
         fix: f.fix,
+        ...(f.affected && f.affected.length > 0 ? { affected: f.affected.slice(0, 15) } : {}),
       });
     }
 
     // Operational issues not in audit
     if (operations.cronFailures24h > 3) {
+      const detailLines = operations.failedCronDetails.map((d) => `${d.name}: ${d.error}`);
       issues.push({
         severity: "high", category: "Operations",
         title: `${operations.cronFailures24h} cron failures in last 24h (${operations.failedCrons.join(", ")})`,
-        rootCause: operations.failedCrons.length > 0 ? `Failed crons: ${operations.failedCrons.join(", ")}. Likely causes: DB pool exhaustion, AI provider timeouts, or budget exceeded.` : "Unknown",
+        rootCause: operations.failedCronDetails.length > 0
+          ? `Latest failure per cron — ${operations.failedCronDetails.map((d) => `${d.name}: ${d.error.slice(0, 120)}`).join(" | ")}`
+          : "Unknown",
         fix: "Check CronJobLog for error messages. Run 'Diagnose' from cockpit to auto-fix stuck jobs.",
+        ...(detailLines.length > 0 ? { affected: detailLines } : {}),
       });
     }
     if (pipeline.stuck > 0) {
@@ -990,8 +1009,8 @@ function buildPlainLanguage(
   indexing: { rate: number; indexed: number; errors: number; chronicFailures: number; neverSubmitted: number },
   gsc: { clicks7d: number; impressions7d: number; avgPosition7d: number; avgCtr7d: number; topPages: Array<{ url: string; clicks: number; impressions: number; position: number }> },
   pipeline: { published: number; publishedThisWeek: number; reservoir: number; stuck: number; inPipeline: number; topicsQueued: number },
-  operations: { cronFailures24h: number; cronSuccesses24h: number; aiCost7d: number; autoFixes7d: number; failedCrons: string[] },
-  issues: Array<{ severity: string; title: string; fix: string }>,
+  operations: { cronFailures24h: number; cronSuccesses24h: number; aiCost7d: number; autoFixes7d: number; failedCrons: string[]; failedCronDetails?: Array<{ name: string; error: string; lastFailedAt: string }> },
+  issues: Array<{ severity: string; title: string; fix: string; affected?: string[] }>,
   latestArticles: Array<{ title: string; slug: string; indexingStatus: string; clicks: number; impressions: number; position: number }>,
   siteName: string,
 ): string {
@@ -1036,6 +1055,12 @@ function buildPlainLanguage(
   lines.push("─── OPERATIONS ───");
   lines.push(`  Cron success rate: ${operations.cronSuccesses24h}/${operations.cronSuccesses24h + operations.cronFailures24h} (24h)`);
   if (operations.failedCrons.length > 0) lines.push(`  Failed: ${operations.failedCrons.join(", ")}`);
+  if (operations.failedCronDetails && operations.failedCronDetails.length > 0) {
+    for (const d of operations.failedCronDetails.slice(0, 5)) {
+      const err = d.error.length > 90 ? d.error.slice(0, 87) + "..." : d.error;
+      lines.push(`    • ${d.name}: ${err}`);
+    }
+  }
   lines.push(`  AI cost (7d):  $${operations.aiCost7d}`);
   lines.push(`  Auto-fixes:    ${operations.autoFixes7d} (7d)`);
   lines.push("");
@@ -1073,10 +1098,18 @@ function buildPlainLanguage(
     for (const i of criticals) {
       lines.push(`  [CRITICAL] ${i.title}`);
       lines.push(`    → ${i.fix}`);
+      if (i.affected && i.affected.length > 0) {
+        for (const a of i.affected.slice(0, 5)) lines.push(`      · ${a.length > 100 ? a.slice(0, 97) + "..." : a}`);
+        if (i.affected.length > 5) lines.push(`      · ...and ${i.affected.length - 5} more`);
+      }
     }
     for (const i of highs.slice(0, 5)) {
       lines.push(`  [HIGH] ${i.title}`);
       lines.push(`    → ${i.fix}`);
+      if (i.affected && i.affected.length > 0) {
+        for (const a of i.affected.slice(0, 3)) lines.push(`      · ${a.length > 100 ? a.slice(0, 97) + "..." : a}`);
+        if (i.affected.length > 3) lines.push(`      · ...and ${i.affected.length - 3} more`);
+      }
     }
     if (highs.length > 5) lines.push(`  ... and ${highs.length - 5} more high-priority issues`);
   }

--- a/yalla_london/app/app/api/admin/audit-roundup/route.ts
+++ b/yalla_london/app/app/api/admin/audit-roundup/route.ts
@@ -205,7 +205,7 @@ export async function runAuditRoundup(siteId: string) {
   }
 
   // Queue monitor — only surface critical/high.
-  for (const rule of queue.rules) {
+  for (const rule of queue.healthRules) {
     if (rule.severity !== "critical" && rule.severity !== "high") continue;
     const sev: Severity = rule.severity;
     actions.push(
@@ -213,7 +213,7 @@ export async function runAuditRoundup(siteId: string) {
         "queue-monitor",
         rule.id,
         sev,
-        rule.message,
+        rule.description,
         undefined,
         rule.affectedDrafts.length || 1,
         rule.autoFixAvailable ? `Run diagnostic-sweep — auto-fixes "${rule.id}"` : `manual: investigate ${rule.id}`,
@@ -321,7 +321,7 @@ export async function runAuditRoundup(siteId: string) {
       },
       queueMonitor: {
         health: queue.overallHealth,
-        criticalRules: queue.rules.filter((r) => r.severity === "critical").length,
+        criticalRules: queue.healthRules.filter((r) => r.severity === "critical").length,
       },
       affiliateRevenue: revenue,
       indexing,

--- a/yalla_london/app/app/api/admin/audit-roundup/route.ts
+++ b/yalla_london/app/app/api/admin/audit-roundup/route.ts
@@ -1,0 +1,356 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+/**
+ * Audit Roundup
+ *
+ * One endpoint that pulls findings from every audit surface in the platform,
+ * scores each finding by ROI (severity × pages-affected × fixability / cost),
+ * and returns a single ranked action queue.
+ *
+ * Sources pulled:
+ *   - runPublicAudit()        → 6-dimension public-website audit (Batches 1-5)
+ *   - getQueueSnapshot()      → pipeline queue health (6 rules)
+ *   - CjCommission + Click    → affiliate revenue summary (last 7d / 30d)
+ *   - URLIndexingStatus       → indexing rate
+ *   - CronJobLog              → recent failure pattern
+ *
+ * Used by:
+ *   - GET /api/admin/audit-roundup     ← this route (dashboard + manual)
+ *   - POST /api/cron/audit-roundup     ← Batch 7 (auto-fix cron)
+ *   - public_audit_roundup MCP tool    ← Batch 8 (cross-MCP enrichment)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin-middleware";
+import { getDefaultSiteId } from "@/config/sites";
+import { prisma } from "@/lib/db";
+import { runPublicAudit } from "@/app/api/admin/public-audit/route";
+import { getQueueSnapshot } from "@/lib/content-pipeline/queue-monitor";
+
+type Severity = "critical" | "high" | "medium" | "low";
+
+const SEVERITY_WEIGHT: Record<Severity, number> = {
+  critical: 10,
+  high: 5,
+  medium: 2,
+  low: 1,
+};
+
+// Maps known nextAction strings to fixability + cost so we can score them.
+// Anything not in this table defaults to manual + medium cost.
+const FIX_PROFILE: Record<string, { fixability: "auto" | "semi-auto" | "manual"; cost: number; cron?: string }> = {
+  "image-pipeline": { fixability: "auto", cost: 1, cron: "/api/cron/image-pipeline" },
+  "seo-agent": { fixability: "auto", cost: 1, cron: "/api/cron/seo-agent" },
+  "seo-deep-review": { fixability: "auto", cost: 1, cron: "/api/cron/seo-deep-review" },
+  "content-auto-fix": { fixability: "auto", cost: 1, cron: "/api/cron/content-auto-fix" },
+  "content-auto-fix-lite": { fixability: "auto", cost: 1, cron: "/api/cron/content-auto-fix-lite" },
+  "affiliate-injection": { fixability: "auto", cost: 1, cron: "/api/cron/affiliate-injection" },
+  "diagnostic-sweep": { fixability: "auto", cost: 1, cron: "/api/cron/diagnostic-sweep" },
+  "content-cleanup": { fixability: "auto", cost: 5, cron: "/api/admin/content-cleanup" },
+  "daily-content-generate": { fixability: "auto", cost: 1, cron: "/api/cron/daily-content-generate" },
+  manual: { fixability: "manual", cost: 20 },
+};
+
+function profileForAction(nextAction: string): {
+  fixability: "auto" | "semi-auto" | "manual";
+  cost: number;
+  cron?: string;
+} {
+  const lower = nextAction.toLowerCase();
+  for (const key of Object.keys(FIX_PROFILE)) {
+    if (lower.includes(key)) return FIX_PROFILE[key];
+  }
+  if (lower.startsWith("manual:") || lower.startsWith("manual ")) {
+    return FIX_PROFILE.manual;
+  }
+  return { fixability: "semi-auto", cost: 5 };
+}
+
+interface RankedAction {
+  source: "public-audit" | "queue-monitor" | "affiliate-revenue" | "indexing" | "cron-failures";
+  dimension?: string;
+  severity: Severity;
+  detail: string;
+  affectedSlug?: string;
+  pagesAffected: number;
+  nextAction: string;
+  fixability: "auto" | "semi-auto" | "manual";
+  cron?: string;
+  cost: number;
+  roiScore: number;
+}
+
+function scoreAction(severity: Severity, pagesAffected: number, fixability: string, cost: number): number {
+  const fxWeight = fixability === "auto" ? 1.0 : fixability === "semi-auto" ? 0.5 : 0.1;
+  return Math.round((SEVERITY_WEIGHT[severity] * Math.max(1, pagesAffected) * fxWeight * 100) / (cost + 1));
+}
+
+function buildAction(
+  source: RankedAction["source"],
+  dimension: string | undefined,
+  severity: Severity,
+  detail: string,
+  affectedSlug: string | undefined,
+  pagesAffected: number,
+  nextAction: string,
+): RankedAction {
+  const profile = profileForAction(nextAction);
+  return {
+    source,
+    dimension,
+    severity,
+    detail,
+    affectedSlug,
+    pagesAffected,
+    nextAction,
+    fixability: profile.fixability,
+    cron: profile.cron,
+    cost: profile.cost,
+    roiScore: scoreAction(severity, pagesAffected, profile.fixability, profile.cost),
+  };
+}
+
+async function buildAffiliateRevenueSummary(siteId: string) {
+  const now = new Date();
+  const d7 = new Date(now.getTime() - 7 * 86400000);
+  const d30 = new Date(now.getTime() - 30 * 86400000);
+  // OR siteId: null pattern from rule #64 — covers legacy unscoped rows.
+  const filter = { OR: [{ siteId }, { siteId: null }] };
+
+  try {
+    const [commissions7d, commissions30d, clicks7d, deadAdvertisers] = await Promise.all([
+      prisma.cjCommission.aggregate({
+        where: { ...filter, eventDate: { gte: d7 } },
+        _sum: { commissionAmount: true },
+      }),
+      prisma.cjCommission.aggregate({
+        where: { ...filter, eventDate: { gte: d30 } },
+        _sum: { commissionAmount: true },
+      }),
+      prisma.cjClickEvent.count({
+        where: { ...filter, createdAt: { gte: d7 } },
+      }),
+      prisma.cjAdvertiser.count({
+        where: { status: { in: ["DECLINED", "CANCELLED", "REMOVED"] } },
+      }),
+    ]);
+
+    return {
+      last7dUsd: Number(commissions7d._sum.commissionAmount) || 0,
+      last30dUsd: Number(commissions30d._sum.commissionAmount) || 0,
+      clicks7d,
+      deadAdvertiserCount: deadAdvertisers,
+    };
+  } catch {
+    // CJ tables may not exist on every site. Don't block the roundup.
+    return {
+      last7dUsd: 0,
+      last30dUsd: 0,
+      clicks7d: 0,
+      deadAdvertiserCount: 0,
+      _unavailable: true,
+    };
+  }
+}
+
+async function buildIndexingSummary(siteId: string) {
+  const [indexed, neverSubmitted, withErrors] = await Promise.all([
+    prisma.uRLIndexingStatus.count({ where: { site_id: siteId, status: "indexed" } }),
+    prisma.uRLIndexingStatus.count({
+      where: { site_id: siteId, submitted_indexnow: false, submitted_google_api: false },
+    }),
+    prisma.uRLIndexingStatus.count({
+      where: { site_id: siteId, last_error: { not: null } },
+    }),
+  ]);
+  return { indexed, neverSubmitted, withErrors };
+}
+
+async function buildCronFailureSummary() {
+  const since = new Date(Date.now() - 24 * 3600000);
+  const failed = await prisma.cronJobLog.findMany({
+    where: { status: "failed", started_at: { gte: since } },
+    orderBy: { started_at: "desc" },
+    take: 20,
+    select: { job_name: true, error_message: true, started_at: true },
+  });
+  // Cluster by job_name so 5 failures of one cron count as one finding.
+  const byJob = new Map<string, { count: number; lastError: string }>();
+  for (const f of failed) {
+    const cur = byJob.get(f.job_name) || { count: 0, lastError: "" };
+    cur.count++;
+    if (!cur.lastError && f.error_message) cur.lastError = f.error_message.slice(0, 200);
+    byJob.set(f.job_name, cur);
+  }
+  return [...byJob.entries()].map(([job, { count, lastError }]) => ({ job, count, lastError }));
+}
+
+export async function runAuditRoundup(siteId: string) {
+  const start = Date.now();
+  const [publicAudit, queue, revenue, indexing, cronFailures] = await Promise.all([
+    runPublicAudit(siteId, 500),
+    getQueueSnapshot(siteId),
+    buildAffiliateRevenueSummary(siteId),
+    buildIndexingSummary(siteId),
+    buildCronFailureSummary(),
+  ]);
+
+  // Convert each source's findings to RankedAction[]
+  const actions: RankedAction[] = [];
+
+  // Public audit topActions — already severity-ranked, one per dim.
+  for (const a of publicAudit.topActions) {
+    actions.push(buildAction("public-audit", a.dimension, a.severity, a.detail, a.affectedSlug, 1, a.nextAction));
+  }
+
+  // Queue monitor — only surface critical/high.
+  for (const rule of queue.rules) {
+    if (rule.severity !== "critical" && rule.severity !== "high") continue;
+    const sev: Severity = rule.severity;
+    actions.push(
+      buildAction(
+        "queue-monitor",
+        rule.id,
+        sev,
+        rule.message,
+        undefined,
+        rule.affectedDrafts.length || 1,
+        rule.autoFixAvailable ? `Run diagnostic-sweep — auto-fixes "${rule.id}"` : `manual: investigate ${rule.id}`,
+      ),
+    );
+  }
+
+  // Affiliate revenue — surface dead advertisers + zero-revenue weeks as
+  // findings. Not technically a "finding" but worth ranking against fixes.
+  if (revenue.deadAdvertiserCount > 0) {
+    actions.push(
+      buildAction(
+        "affiliate-revenue",
+        "dead-advertisers",
+        "high",
+        `${revenue.deadAdvertiserCount} CJ advertisers in DECLINED/CANCELLED/REMOVED status — links earn $0`,
+        undefined,
+        revenue.deadAdvertiserCount,
+        "Run affiliate-injection cron — swaps dead links for live partners",
+      ),
+    );
+  }
+  if (revenue.last7dUsd === 0 && revenue.clicks7d > 0) {
+    actions.push(
+      buildAction(
+        "affiliate-revenue",
+        "zero-revenue",
+        "medium",
+        `${revenue.clicks7d} affiliate clicks in last 7d but $0 commission — attribution chain broken`,
+        undefined,
+        1,
+        "manual: verify SID parameter format on tracked links",
+      ),
+    );
+  }
+
+  // Indexing — never-submitted backlog as a single finding.
+  if (indexing.neverSubmitted >= 20) {
+    actions.push(
+      buildAction(
+        "indexing",
+        "never-submitted",
+        "high",
+        `${indexing.neverSubmitted} URLs never submitted to IndexNow — invisible to Bing/Yandex`,
+        undefined,
+        indexing.neverSubmitted,
+        "Run content-auto-fix-lite — Section 7 catches these in batches of 200",
+      ),
+    );
+  }
+  if (indexing.withErrors >= 10) {
+    actions.push(
+      buildAction(
+        "indexing",
+        "submission-errors",
+        "medium",
+        `${indexing.withErrors} URLs have IndexNow submission errors`,
+        undefined,
+        indexing.withErrors,
+        "Run seo-agent — retries failed submissions with exponential backoff",
+      ),
+    );
+  }
+
+  // Cron failures — each clustered job = one finding.
+  for (const f of cronFailures) {
+    if (f.count < 2) continue; // single failures aren't worth surfacing
+    const sev: Severity = f.count >= 5 ? "critical" : "high";
+    actions.push(
+      buildAction(
+        "cron-failures",
+        f.job,
+        sev,
+        `${f.job} failed ${f.count}x in 24h — last error: ${f.lastError || "(no message)"}`,
+        undefined,
+        1,
+        `manual: check CEO Inbox for ${f.job} auto-fix attempts`,
+      ),
+    );
+  }
+
+  // Sort by ROI score descending. Cap at 20 for surfacing, keep all in `all`.
+  actions.sort((a, b) => b.roiScore - a.roiScore);
+  const topActions = actions.slice(0, 20);
+
+  // Plain-language summary.
+  const totalCritical = actions.filter((a) => a.severity === "critical").length;
+  const totalHigh = actions.filter((a) => a.severity === "high").length;
+  const autoFixable = actions.filter((a) => a.fixability === "auto").length;
+  const summary =
+    actions.length === 0
+      ? `Site ${siteId} is healthy. No critical or high actions across 5 audit sources.`
+      : `Site ${siteId}: ${totalCritical} critical + ${totalHigh} high-severity actions across ${actions.length} total findings. ${autoFixable} are auto-fixable. Top action by ROI: ${topActions[0]?.detail || "(none)"}`;
+
+  return {
+    site: siteId,
+    generatedAt: new Date().toISOString(),
+    durationMs: Date.now() - start,
+    sources: {
+      publicAudit: {
+        grade: publicAudit.overallGrade,
+        score: publicAudit.overallScore,
+        critical: Object.values(publicAudit.dimensions).reduce((s, d) => s + d.bySeverity.critical, 0),
+        high: Object.values(publicAudit.dimensions).reduce((s, d) => s + d.bySeverity.high, 0),
+      },
+      queueMonitor: {
+        health: queue.overallHealth,
+        criticalRules: queue.rules.filter((r) => r.severity === "critical").length,
+      },
+      affiliateRevenue: revenue,
+      indexing,
+      cronFailures: { uniqueJobs: cronFailures.length, totalFailures: cronFailures.reduce((s, f) => s + f.count, 0) },
+    },
+    totals: {
+      findings: actions.length,
+      critical: totalCritical,
+      high: totalHigh,
+      autoFixable,
+    },
+    topActions,
+    allActions: actions,
+    plainLanguageSummary: summary,
+    _format: "yalla-audit-roundup-v1",
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const authError = await requireAdmin(request);
+  if (authError) return authError;
+  const siteId = request.nextUrl.searchParams.get("siteId") || getDefaultSiteId();
+  try {
+    const report = await runAuditRoundup(siteId);
+    return NextResponse.json({ success: true, ...report });
+  } catch (err: unknown) {
+    return NextResponse.json(
+      { success: false, error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/yalla_london/app/app/api/admin/content-cleanup/route.ts
+++ b/yalla_london/app/app/api/admin/content-cleanup/route.ts
@@ -99,11 +99,16 @@ function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
 }
 
 function normalizeSlug(slug: string): string {
-  return slug
-    .replace(SLUG_ARTIFACT_PATTERN, "")
-    .replace(/-20\d{2}(-\d{2}(-\d{2})?)?/g, "")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
+  // Iterate until idempotent — handles stacked suffixes like `-v2-v2` and
+  // `-v9-75b0dea7` where a single regex pass would leave one suffix attached.
+  // Cap at 5 iterations to avoid pathological inputs.
+  let result = slug;
+  for (let i = 0; i < 5; i++) {
+    const before = result;
+    result = result.replace(SLUG_ARTIFACT_PATTERN, "").replace(/-20\d{2}(-\d{2}(-\d{2})?)?/g, "");
+    if (result === before) break;
+  }
+  return result.replace(/-+/g, "-").replace(/^-|-$/g, "");
 }
 
 interface ArticleRow {

--- a/yalla_london/app/app/api/admin/departures/route.ts
+++ b/yalla_london/app/app/api/admin/departures/route.ts
@@ -12,10 +12,10 @@
 export const dynamic = "force-dynamic";
 export const maxDuration = 300; // POST triggers cron routes that can take up to 280s (gsc-sync, content-selector)
 
-import { NextRequest, NextResponse } from 'next/server';
-import { requireAdmin } from '@/lib/admin-middleware';
-import { getActiveSiteIds, getDefaultSiteId } from '@/config/sites';
-import { logManualAction } from '@/lib/action-logger';
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin-middleware";
+import { getActiveSiteIds, getDefaultSiteId } from "@/config/sites";
+import { logManualAction } from "@/lib/action-logger";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -24,24 +24,24 @@ import { logManualAction } from '@/lib/action-logger';
 export interface Departure {
   id: string;
   label: string;
-  type: 'cron' | 'publication' | 'audit' | 'content';
+  type: "cron" | "publication" | "audit" | "content";
   icon: string; // emoji used as visual indicator
-  scheduledAt: string | null;      // ISO string, null = "on demand"
-  countdownMs: number | null;      // ms until scheduledAt (negative = overdue)
-  status: 'scheduled' | 'running' | 'overdue' | 'ready' | 'on_demand';
-  cronPath: string | null;         // POST target for "Do Now"
-  cronSchedule: string | null;     // human-readable schedule string
-  lastRunAt: string | null;        // ISO string of last execution
-  lastRunStatus: 'success' | 'failed' | 'unknown' | null;
+  scheduledAt: string | null; // ISO string, null = "on demand"
+  countdownMs: number | null; // ms until scheduledAt (negative = overdue)
+  status: "scheduled" | "running" | "overdue" | "ready" | "on_demand";
+  cronPath: string | null; // POST target for "Do Now"
+  cronSchedule: string | null; // human-readable schedule string
+  lastRunAt: string | null; // ISO string of last execution
+  lastRunStatus: "success" | "failed" | "unknown" | null;
   siteId: string | null;
   meta?: Record<string, string | number>;
   // Phase 6 enhancements
-  description: string | null;      // plain-English "what will happen"
-  category: string | null;         // content | seo | analytics | maintenance | publishing
-  feedsInto: string | null;        // what this cron feeds into
-  successRate7d: number | null;    // 7-day success rate (0-100)
-  avgDurationMs: number | null;    // average execution duration
-  lastError: string | null;        // plain-English last error message
+  description: string | null; // plain-English "what will happen"
+  category: string | null; // content | seo | analytics | maintenance | publishing
+  feedsInto: string | null; // what this cron feeds into
+  successRate7d: number | null; // 7-day success rate (0-100)
+  avgDurationMs: number | null; // average execution duration
+  lastError: string | null; // plain-English last error message
 }
 
 // ---------------------------------------------------------------------------
@@ -53,67 +53,578 @@ interface CronDef {
   schedule: string;
   label: string;
   icon: string;
-  type: 'cron';
+  type: "cron";
   description: string;
-  category: 'content' | 'seo' | 'analytics' | 'maintenance' | 'publishing' | 'ai' | 'email' | 'agent';
+  category: "content" | "seo" | "analytics" | "maintenance" | "publishing" | "ai" | "email" | "agent";
   feedsInto?: string;
 }
 
 const CRON_DEFS: CronDef[] = [
-  { path: '/api/cron/analytics',              schedule: '30 2 * * *',          label: 'Analytics Sync',            icon: '📊', type: 'cron', category: 'analytics',    description: 'Syncs GA4 + Search Console data into the dashboard. Updates traffic, clicks, and keyword rankings.',           feedsInto: 'Dashboard metrics' },
-  { path: '/api/cron/gsc-sync',               schedule: '0 4 * * *',          label: 'GSC Data Sync',             icon: '📡', type: 'cron', category: 'seo',          description: 'Pulls per-page clicks/impressions/CTR/position from Google Search Console. Cross-references indexing status — URLs with impressions confirmed indexed.', feedsInto: 'Cockpit + Content Matrix' },
-  { path: '/api/cron/weekly-topics',          schedule: '10 4 * * *',          label: 'Topic Research (daily)',    icon: '🔍', type: 'cron', category: 'content',      description: 'Generates new content topic ideas for all active sites. Full generation Mondays, backlog-refill other days.', feedsInto: 'Content Builder' },
-  { path: '/api/cron/daily-content-generate', schedule: '0 5 * * *',          label: 'Daily Content Generation',  icon: '✍️', type: 'cron', category: 'content',      description: 'Creates new article drafts from approved topics. Each draft enters the 8-phase pipeline.',                     feedsInto: 'Content Builder' },
-  { path: '/api/cron/seo-orchestrator?mode=weekly', schedule: '0 5 * * 0',   label: 'SEO Orchestrator (weekly)', icon: '🎯', type: 'cron', category: 'seo',          description: 'Deep weekly SEO audit. Checks indexing gaps, content quality, schema markup, and generates health reports.',    feedsInto: 'SEO Reports' },
-  { path: '/api/cron/trends-monitor',         schedule: '0 6 * * *',          label: 'Trends Monitor',            icon: '📈', type: 'cron', category: 'content',      description: 'Scans trending topics for timely content opportunities. Creates urgent topic proposals for viral moments.',     feedsInto: 'Weekly Topics' },
-  { path: '/api/cron/seo-orchestrator?mode=daily', schedule: '10 6 * * *',   label: 'SEO Orchestrator (daily)',  icon: '🎯', type: 'cron', category: 'seo',          description: 'Daily SEO maintenance. Checks for new indexing issues and updates SEO health scores.',                        feedsInto: 'SEO Agent' },
-  { path: '/api/cron/london-news',            schedule: '40 6,14 * * *',      label: 'London News Fetch',         icon: '📰', type: 'cron', category: 'content',      description: 'Fetches London-specific news and generates timely news articles for the site.',                                feedsInto: 'Published content' },
-  { path: '/api/cron/seo-agent',              schedule: '0 7 * * *',          label: 'SEO Agent (morning)',       icon: '🤖', type: 'cron', category: 'seo',          description: 'Auto-fixes meta titles/descriptions, injects internal links, discovers new pages for IndexNow submission.',   feedsInto: 'IndexNow' },
-  { path: '/api/seo/cron?task=daily',         schedule: '30 7 * * *',         label: 'IndexNow Submission',       icon: '🔗', type: 'cron', category: 'seo',          description: 'Submits new/updated URLs to IndexNow for instant search engine discovery. Faster than waiting for crawlers.',  feedsInto: 'Google indexing' },
-  { path: '/api/cron/sweeper',               schedule: '45 8,14,20 * * *',    label: 'DB Sweeper / Cleanup',      icon: '🧹', type: 'cron', category: 'maintenance',  description: 'Cleans up old logs, expired sessions, and stale data. Keeps the database lean and performant.' },
-  { path: '/api/seo/cron?task=weekly',        schedule: '0 8 * * 0',          label: 'SEO Cron (weekly)',         icon: '🔗', type: 'cron', category: 'seo',          description: 'Weekly deep sitemap and indexing analysis. Checks for broken links, duplicate content, and orphan pages.',     feedsInto: 'SEO Reports' },
-  { path: '/api/cron/content-builder',        schedule: '8,23,38,53 * * * *', label: 'Content Builder (15min)',   icon: '🏗️', type: 'cron', category: 'content',      description: 'Advances article drafts through the 8-phase pipeline. Full 53s budget dedicated to AI phase execution.', feedsInto: 'Content Selector' },
-  { path: '/api/cron/content-builder-create', schedule: '7 */1 * * *',        label: 'Draft Creator (hourly)',    icon: '📝', type: 'cron', category: 'content',      description: 'Creates new EN+AR draft pairs from topic queue. DB-only, no AI calls. Separated so builder gets full budget for phases.', feedsInto: 'Content Builder' },
-  { path: '/api/cron/content-selector',       schedule: '5 7,9,11,13,15,17,19,21 * * *', label: 'Content Selector',  icon: '✅', type: 'cron', category: 'publishing',   description: 'Selects highest-quality articles from the reservoir and schedules them for publication.',                      feedsInto: 'Scheduled Publish' },
-  { path: '/api/cron/affiliate-injection',    schedule: '25 9 * * *',         label: 'Affiliate Injection',       icon: '💰', type: 'cron', category: 'content',      description: 'Injects affiliate and booking links (HalalBooking, Booking.com, Viator) into published articles for revenue.' },
-  { path: '/api/affiliate/cron/sync-advertisers',  schedule: '30 0,6,12,18 * * *', label: 'CJ Advertiser Sync',    icon: '🤝', type: 'cron', category: 'content',      description: 'Syncs CJ advertiser statuses. Detects newly approved advertisers and auto-fetches their links/products.',     feedsInto: 'Affiliate Injection' },
-  { path: '/api/affiliate/cron/sync-commissions',  schedule: '50 6 * * *',          label: 'CJ Commission Sync',    icon: '💵', type: 'cron', category: 'content',      description: 'Fetches commission data from CJ for the last 7 days. Updates revenue dashboard with real earnings.' },
-  { path: '/api/affiliate/cron/discover-deals',    schedule: '30 5 * * *',          label: 'CJ Deal Discovery',     icon: '🏷️', type: 'cron', category: 'content',      description: 'Searches CJ product catalog for new deals and price drops relevant to each site destination.' },
-  { path: '/api/affiliate/cron/refresh-links',     schedule: '15 3 * * 0',         label: 'CJ Link Refresh',       icon: '🔗', type: 'cron', category: 'content',      description: 'Refreshes affiliate tracking links from CJ for all joined advertisers. Deactivates expired links.' },
-  { path: '/api/cron/scheduled-publish',      schedule: '15 9 * * *',         label: 'Scheduled Publish (9am)',   icon: '🚀', type: 'cron', category: 'publishing',   description: 'Publishes scheduled articles at 9am UTC. Each article passes the 16-check pre-publication gate.',              feedsInto: 'SEO Agent' },
-  { path: '/api/cron/scheduled-publish',      schedule: '15 12 * * *',        label: 'Scheduled Publish (noon)',  icon: '🚀', type: 'cron', category: 'publishing',   description: 'Noon publish window. Publishes remaining scheduled content.',                                                  feedsInto: 'SEO Agent' },
-  { path: '/api/cron/google-indexing',        schedule: '35 9 * * *',         label: 'Google Indexing Submit',    icon: '🔎', type: 'cron', category: 'seo',          description: 'Submits newly published pages to Google via the Indexing API for faster crawling and indexing.' },
-  { path: '/api/cron/seo-agent',              schedule: '0 13 * * *',         label: 'SEO Agent (afternoon)',     icon: '🤖', type: 'cron', category: 'seo',          description: 'Afternoon SEO pass. Catches newly published articles and fixes any meta tag or link issues.',                 feedsInto: 'IndexNow' },
-  { path: '/api/cron/seo-agent-intelligence', schedule: '0 14 * * *',         label: 'SEO Intelligence (AI)',     icon: '🧠', type: 'cron', category: 'seo',          description: 'AI-powered: GSC analysis, low-CTR meta rewriting, content strengthening, GA4 traffic analysis, content strategy.', feedsInto: 'Content Strategy' },
-  { path: '/api/cron/scheduled-publish',      schedule: '0 16 * * *',         label: 'Scheduled Publish (4pm)',   icon: '🚀', type: 'cron', category: 'publishing',   description: 'Afternoon publish window. Publishes remaining scheduled content for the day.',                                feedsInto: 'SEO Agent' },
-  { path: '/api/cron/verify-indexing',        schedule: '5 11,17 * * *',      label: 'Verify Indexing (2x)',      icon: '✔️', type: 'cron', category: 'seo',          description: 'Checks previously submitted URLs to confirm Google has indexed them. Updates indexing status in the database.' },
-  { path: '/api/cron/content-auto-fix-lite',  schedule: '40 0,4,8,12,16,20 * * *', label: 'Auto-Fix Lite (6x)',  icon: '🔧', type: 'cron', category: 'content',      description: 'Fast DB-only fixes: stuck draft recovery, heading hierarchy, meta description trims. Every 4 hours.',          feedsInto: 'Content Builder' },
-  { path: '/api/cron/content-auto-fix',       schedule: '0 11,18 * * *',      label: 'Auto-Fix Heavy (AI)',       icon: '🔧', type: 'cron', category: 'content',      description: 'AI-powered: word count expansion, quality score enhancement, link injection, Arabic meta generation. 2x daily.', feedsInto: 'Quality gate' },
-  { path: '/api/cron/seo-agent',              schedule: '0 20 * * *',         label: 'SEO Agent (evening)',       icon: '🤖', type: 'cron', category: 'seo',          description: 'Evening SEO sweep. Final daily check for missing meta tags, internal links, and schema markup.',               feedsInto: 'IndexNow' },
-  { path: '/api/cron/site-health-check',      schedule: '0 22 * * *',         label: 'Site Health Check',         icon: '❤️', type: 'cron', category: 'maintenance',  description: 'Nightly health check across all configured sites. Detects downtime, slow responses, and configuration issues.' },
-  { path: '/api/cron/reserve-publisher',      schedule: '10 21 * * *',        label: 'Reserve Publisher',         icon: '🛡️', type: 'cron', category: 'publishing',   description: 'Daily safety net. At 9pm UTC, checks if each site published 1 EN + 1 AR article today. If not, generates and publishes from reservoir or scratch. Guarantees daily minimums.',  feedsInto: 'SEO Deep Review' },
-  { path: '/api/cron/seo-deep-review',        schedule: '0 0 * * *',          label: 'SEO Deep Review',           icon: '🔬', type: 'cron', category: 'seo',          description: '3 hours after reserve-publisher. ACTIVELY FIXES every SEO dimension on articles published today: meta, links, headings, content expansion, affiliate injection, alt text, then resubmits to IndexNow.', feedsInto: 'IndexNow' },
-  { path: '/api/cron/fact-verification',      schedule: '0 3 * * 0',          label: 'Fact Verification',         icon: '🔬', type: 'cron', category: 'content',      description: 'Weekly fact-check pass on generated content. Flags suspicious claims and verifies key data points.' },
-  { path: '/api/cron/campaign-executor',      schedule: '12,42 * * * *',      label: 'Campaign Agent',            icon: '🎯', type: 'cron', category: 'content',      description: 'Processes active campaign batches. Enhances published articles, injects affiliates, fixes headings, expands Arabic content. 2x per hour.',  feedsInto: 'Published content' },
-  { path: '/api/cron/pipeline-health',       schedule: '30 1,7,13,19 * * *', label: 'Pipeline Health Monitor',   icon: '📋', type: 'cron', category: 'maintenance',  description: 'Snapshots pipeline throughput, bottlenecks, active count accuracy, recovery agent conflicts, and AI provider health. Pure observation — never modifies data.' },
-  { path: '/api/cron/perplexity-scheduler',  schedule: '10 */2 * * *',       label: 'Perplexity Scheduler',      icon: '🔮', type: 'cron', category: 'ai',            description: 'Processes due Perplexity Computer schedules. Creates tasks from templates for recurring research, audits, and monitoring.',  feedsInto: 'Perplexity Executor' },
-  { path: '/api/cron/perplexity-executor',   schedule: '20,50 * * * *',      label: 'Perplexity Executor',       icon: '⚡', type: 'cron', category: 'ai',            description: 'Executes ready Perplexity Computer tasks by calling the Perplexity API. Processes up to 5 tasks per run with rate limiting.',  feedsInto: 'Task Results' },
-  { path: '/api/cron/diagnostic-sweep',      schedule: '55 1,3,5,7,9,11,13,15,17,19,21,23 * * *', label: 'Diagnostic Sweep', icon: '🔍', type: 'cron', category: 'maintenance',  description: 'Runs diagnostic agent to auto-fix stuck drafts, timeout loops, and pipeline blockages every 2 hours.',  feedsInto: 'AutoFixLog' },
-  { path: '/api/cron/ceo-intelligence',      schedule: '50 5 * * 0',         label: 'CEO Intelligence',          icon: '🧠', type: 'cron', category: 'maintenance',  description: 'Weekly autonomous intelligence: gathers GA4/GSC metrics, runs cleanup, compares KPIs, generates plans, reviews standards, emails CEO report.',  feedsInto: 'CEO Email Report' },
-  { path: '/api/cron/data-refresh',           schedule: '45 6 * * *',         label: 'Data Refresh',              icon: '🔄', type: 'cron', category: 'maintenance',  description: 'Refreshes currency, weather, holidays, and countries caches daily.',  feedsInto: 'Foundation APIs' },
-  { path: '/api/cron/events-sync',            schedule: '45 6 * * 1',         label: 'Events Sync',               icon: '🎫', type: 'cron', category: 'content',      description: 'Fetches Ticketmaster events weekly for homepage display.',  feedsInto: 'Homepage Events' },
-  { path: '/api/cron/image-pipeline',         schedule: '20 2,10,18 * * *',   label: 'Image Pipeline (3x)',       icon: '🖼️', type: 'cron', category: 'content',      description: 'Stocks media library from Unsplash and assigns featured images to articles.',  feedsInto: 'MediaAsset' },
-  { path: '/api/cron/process-indexing-queue',  schedule: '25 7,13,20 * * *', label: 'IndexNow Queue', icon: '📡', type: 'cron', category: 'seo',     description: 'Processes pending URLs and submits to IndexNow (Bing, Yandex, api.indexnow.org).',  feedsInto: 'IndexNow Engines' },
-  { path: '/api/cron/discovery-monitor',      schedule: '0 3,9,15,21 * * *',  label: 'Discovery Monitor',         icon: '🔎', type: 'cron', category: 'seo',          description: 'Monitors URL discovery and indexing health 4x daily.',  feedsInto: 'Indexing Dashboard' },
-  { path: '/api/cron/daily-seo-audit',        schedule: '20 5 * * *',         label: 'Daily SEO Audit',           icon: '📊', type: 'cron', category: 'seo',          description: 'Runs daily SEO audit checks across all published pages.',  feedsInto: 'SEO Reports' },
-  { path: '/api/cron/agent-maintenance',      schedule: '30 6 * * 0',         label: 'CTO Agent Maintenance',     icon: '🔧', type: 'cron', category: 'maintenance',  description: 'Weekly CTO Agent maintenance loop: scans codebase, checks cron/pipeline health, researches fixes, proposes improvements.',  feedsInto: 'AgentTask' },
-  { path: '/api/cron/retention-executor',     schedule: '30 0,4,8,12,16,20 * * *', label: 'Retention Executor',   icon: '📧', type: 'cron', category: 'email',        description: 'Sends due retention emails (welcome series, post-booking follow-ups), triggers re-engagement for 30d+ inactive subscribers, seeds default sequences.', feedsInto: 'RetentionProgress' },
-  { path: '/api/cron/followup-executor',      schedule: '5 1,5,9,13,17,21 * * *',  label: 'Follow-up Executor',   icon: '🔄', type: 'cron', category: 'agent',        description: 'Processes due CEO Agent follow-up tasks by re-invoking CEO Brain. Picks up AgentTask records with dueAt <= now.', feedsInto: 'AgentTask' },
-  { path: '/api/cron/schedule-executor',     schedule: '20 1,3,5,7,9,11,13,15,17,19,21,23 * * *', label: 'Schedule Executor', icon: '📅', type: 'cron', category: 'content', description: 'Creates EN+AR draft pairs from ContentScheduleRule every 2h. Seeds default rule on first run. Critical for pipeline throughput.', feedsInto: 'Content Builder' },
-  { path: '/api/cron/content-freshness',     schedule: '0 10 * * 0',         label: 'Content Freshness',         icon: '🔄', type: 'cron', category: 'content',      description: 'Weekly freshness check on published articles. Flags stale content for update or rewrite.' },
-  { path: '/api/cron/seo-audit-runner',      schedule: '0 2 * * *',          label: 'SEO Audit Runner',          icon: '📊', type: 'cron', category: 'seo',          description: 'Daily automated SEO audit across all published pages. Generates SeoAuditReport records.',   feedsInto: 'SEO Reports' },
-  { path: '/api/cron/social',                schedule: '5 10,15,20 * * *',   label: 'Social Publisher',          icon: '📣', type: 'cron', category: 'content',      description: 'Auto-publishes scheduled social posts (Twitter). Flags other platforms as pending manual.', feedsInto: 'Social Calendar' },
-  { path: '/api/cron/subscriber-emails',     schedule: '10 11 * * *',        label: 'Subscriber Emails',         icon: '📬', type: 'cron', category: 'email',        description: 'Sends daily subscriber digest emails. Processes email queue for welcome sequences and newsletters.' },
+  {
+    path: "/api/cron/analytics",
+    schedule: "30 2 * * *",
+    label: "Analytics Sync",
+    icon: "📊",
+    type: "cron",
+    category: "analytics",
+    description: "Syncs GA4 + Search Console data into the dashboard. Updates traffic, clicks, and keyword rankings.",
+    feedsInto: "Dashboard metrics",
+  },
+  {
+    path: "/api/cron/gsc-sync",
+    schedule: "0 4 * * *",
+    label: "GSC Data Sync",
+    icon: "📡",
+    type: "cron",
+    category: "seo",
+    description:
+      "Pulls per-page clicks/impressions/CTR/position from Google Search Console. Cross-references indexing status — URLs with impressions confirmed indexed.",
+    feedsInto: "Cockpit + Content Matrix",
+  },
+  {
+    path: "/api/cron/weekly-topics",
+    schedule: "10 4 * * *",
+    label: "Topic Research (daily)",
+    icon: "🔍",
+    type: "cron",
+    category: "content",
+    description:
+      "Generates new content topic ideas for all active sites. Full generation Mondays, backlog-refill other days.",
+    feedsInto: "Content Builder",
+  },
+  {
+    path: "/api/cron/daily-content-generate",
+    schedule: "0 5 * * *",
+    label: "Daily Content Generation",
+    icon: "✍️",
+    type: "cron",
+    category: "content",
+    description: "Creates new article drafts from approved topics. Each draft enters the 8-phase pipeline.",
+    feedsInto: "Content Builder",
+  },
+  {
+    path: "/api/cron/seo-orchestrator?mode=weekly",
+    schedule: "0 5 * * 0",
+    label: "SEO Orchestrator (weekly)",
+    icon: "🎯",
+    type: "cron",
+    category: "seo",
+    description:
+      "Deep weekly SEO audit. Checks indexing gaps, content quality, schema markup, and generates health reports.",
+    feedsInto: "SEO Reports",
+  },
+  {
+    path: "/api/cron/trends-monitor",
+    schedule: "0 6 * * *",
+    label: "Trends Monitor",
+    icon: "📈",
+    type: "cron",
+    category: "content",
+    description:
+      "Scans trending topics for timely content opportunities. Creates urgent topic proposals for viral moments.",
+    feedsInto: "Weekly Topics",
+  },
+  {
+    path: "/api/cron/seo-orchestrator?mode=daily",
+    schedule: "10 6 * * *",
+    label: "SEO Orchestrator (daily)",
+    icon: "🎯",
+    type: "cron",
+    category: "seo",
+    description: "Daily SEO maintenance. Checks for new indexing issues and updates SEO health scores.",
+    feedsInto: "SEO Agent",
+  },
+  {
+    path: "/api/cron/london-news",
+    schedule: "40 6,14 * * *",
+    label: "London News Fetch",
+    icon: "📰",
+    type: "cron",
+    category: "content",
+    description: "Fetches London-specific news and generates timely news articles for the site.",
+    feedsInto: "Published content",
+  },
+  {
+    path: "/api/cron/seo-agent",
+    schedule: "0 7 * * *",
+    label: "SEO Agent (morning)",
+    icon: "🤖",
+    type: "cron",
+    category: "seo",
+    description:
+      "Auto-fixes meta titles/descriptions, injects internal links, discovers new pages for IndexNow submission.",
+    feedsInto: "IndexNow",
+  },
+  {
+    path: "/api/seo/cron?task=daily",
+    schedule: "30 7 * * *",
+    label: "IndexNow Submission",
+    icon: "🔗",
+    type: "cron",
+    category: "seo",
+    description:
+      "Submits new/updated URLs to IndexNow for instant search engine discovery. Faster than waiting for crawlers.",
+    feedsInto: "Google indexing",
+  },
+  {
+    path: "/api/cron/sweeper",
+    schedule: "45 8,14,20 * * *",
+    label: "DB Sweeper / Cleanup",
+    icon: "🧹",
+    type: "cron",
+    category: "maintenance",
+    description: "Cleans up old logs, expired sessions, and stale data. Keeps the database lean and performant.",
+  },
+  {
+    path: "/api/seo/cron?task=weekly",
+    schedule: "0 8 * * 0",
+    label: "SEO Cron (weekly)",
+    icon: "🔗",
+    type: "cron",
+    category: "seo",
+    description:
+      "Weekly deep sitemap and indexing analysis. Checks for broken links, duplicate content, and orphan pages.",
+    feedsInto: "SEO Reports",
+  },
+  {
+    path: "/api/cron/content-builder",
+    schedule: "8,23,38,53 * * * *",
+    label: "Content Builder (15min)",
+    icon: "🏗️",
+    type: "cron",
+    category: "content",
+    description:
+      "Advances article drafts through the 8-phase pipeline. Full 53s budget dedicated to AI phase execution.",
+    feedsInto: "Content Selector",
+  },
+  {
+    path: "/api/cron/content-builder-create",
+    schedule: "7 */1 * * *",
+    label: "Draft Creator (hourly)",
+    icon: "📝",
+    type: "cron",
+    category: "content",
+    description:
+      "Creates new EN+AR draft pairs from topic queue. DB-only, no AI calls. Separated so builder gets full budget for phases.",
+    feedsInto: "Content Builder",
+  },
+  {
+    path: "/api/cron/content-selector",
+    schedule: "5 7,9,11,13,15,17,19,21 * * *",
+    label: "Content Selector",
+    icon: "✅",
+    type: "cron",
+    category: "publishing",
+    description: "Selects highest-quality articles from the reservoir and schedules them for publication.",
+    feedsInto: "Scheduled Publish",
+  },
+  {
+    path: "/api/cron/affiliate-injection",
+    schedule: "25 9 * * *",
+    label: "Affiliate Injection",
+    icon: "💰",
+    type: "cron",
+    category: "content",
+    description:
+      "Injects affiliate and booking links (HalalBooking, Booking.com, Viator) into published articles for revenue.",
+  },
+  {
+    path: "/api/affiliate/cron/sync-advertisers",
+    schedule: "30 0,6,12,18 * * *",
+    label: "CJ Advertiser Sync",
+    icon: "🤝",
+    type: "cron",
+    category: "content",
+    description:
+      "Syncs CJ advertiser statuses. Detects newly approved advertisers and auto-fetches their links/products.",
+    feedsInto: "Affiliate Injection",
+  },
+  {
+    path: "/api/affiliate/cron/sync-commissions",
+    schedule: "50 6 * * *",
+    label: "CJ Commission Sync",
+    icon: "💵",
+    type: "cron",
+    category: "content",
+    description: "Fetches commission data from CJ for the last 7 days. Updates revenue dashboard with real earnings.",
+  },
+  {
+    path: "/api/affiliate/cron/discover-deals",
+    schedule: "30 5 * * *",
+    label: "CJ Deal Discovery",
+    icon: "🏷️",
+    type: "cron",
+    category: "content",
+    description: "Searches CJ product catalog for new deals and price drops relevant to each site destination.",
+  },
+  {
+    path: "/api/affiliate/cron/refresh-links",
+    schedule: "15 3 * * 0",
+    label: "CJ Link Refresh",
+    icon: "🔗",
+    type: "cron",
+    category: "content",
+    description: "Refreshes affiliate tracking links from CJ for all joined advertisers. Deactivates expired links.",
+  },
+  {
+    path: "/api/cron/scheduled-publish",
+    schedule: "15 9 * * *",
+    label: "Scheduled Publish (9am)",
+    icon: "🚀",
+    type: "cron",
+    category: "publishing",
+    description: "Publishes scheduled articles at 9am UTC. Each article passes the 16-check pre-publication gate.",
+    feedsInto: "SEO Agent",
+  },
+  {
+    path: "/api/cron/scheduled-publish",
+    schedule: "15 12 * * *",
+    label: "Scheduled Publish (noon)",
+    icon: "🚀",
+    type: "cron",
+    category: "publishing",
+    description: "Noon publish window. Publishes remaining scheduled content.",
+    feedsInto: "SEO Agent",
+  },
+  {
+    path: "/api/cron/google-indexing",
+    schedule: "35 9 * * *",
+    label: "Google Indexing Submit",
+    icon: "🔎",
+    type: "cron",
+    category: "seo",
+    description: "Submits newly published pages to Google via the Indexing API for faster crawling and indexing.",
+  },
+  {
+    path: "/api/cron/seo-agent",
+    schedule: "0 13 * * *",
+    label: "SEO Agent (afternoon)",
+    icon: "🤖",
+    type: "cron",
+    category: "seo",
+    description: "Afternoon SEO pass. Catches newly published articles and fixes any meta tag or link issues.",
+    feedsInto: "IndexNow",
+  },
+  {
+    path: "/api/cron/seo-agent-intelligence",
+    schedule: "0 14 * * *",
+    label: "SEO Intelligence (AI)",
+    icon: "🧠",
+    type: "cron",
+    category: "seo",
+    description:
+      "AI-powered: GSC analysis, low-CTR meta rewriting, content strengthening, GA4 traffic analysis, content strategy.",
+    feedsInto: "Content Strategy",
+  },
+  {
+    path: "/api/cron/scheduled-publish",
+    schedule: "0 16 * * *",
+    label: "Scheduled Publish (4pm)",
+    icon: "🚀",
+    type: "cron",
+    category: "publishing",
+    description: "Afternoon publish window. Publishes remaining scheduled content for the day.",
+    feedsInto: "SEO Agent",
+  },
+  {
+    path: "/api/cron/verify-indexing",
+    schedule: "5 11,17 * * *",
+    label: "Verify Indexing (2x)",
+    icon: "✔️",
+    type: "cron",
+    category: "seo",
+    description:
+      "Checks previously submitted URLs to confirm Google has indexed them. Updates indexing status in the database.",
+  },
+  {
+    path: "/api/cron/content-auto-fix-lite",
+    schedule: "40 0,4,8,12,16,20 * * *",
+    label: "Auto-Fix Lite (6x)",
+    icon: "🔧",
+    type: "cron",
+    category: "content",
+    description: "Fast DB-only fixes: stuck draft recovery, heading hierarchy, meta description trims. Every 4 hours.",
+    feedsInto: "Content Builder",
+  },
+  {
+    path: "/api/cron/content-auto-fix",
+    schedule: "0 11,18 * * *",
+    label: "Auto-Fix Heavy (AI)",
+    icon: "🔧",
+    type: "cron",
+    category: "content",
+    description:
+      "AI-powered: word count expansion, quality score enhancement, link injection, Arabic meta generation. 2x daily.",
+    feedsInto: "Quality gate",
+  },
+  {
+    path: "/api/cron/seo-agent",
+    schedule: "0 20 * * *",
+    label: "SEO Agent (evening)",
+    icon: "🤖",
+    type: "cron",
+    category: "seo",
+    description: "Evening SEO sweep. Final daily check for missing meta tags, internal links, and schema markup.",
+    feedsInto: "IndexNow",
+  },
+  {
+    path: "/api/cron/site-health-check",
+    schedule: "0 22 * * *",
+    label: "Site Health Check",
+    icon: "❤️",
+    type: "cron",
+    category: "maintenance",
+    description:
+      "Nightly health check across all configured sites. Detects downtime, slow responses, and configuration issues.",
+  },
+  {
+    path: "/api/cron/reserve-publisher",
+    schedule: "10 21 * * *",
+    label: "Reserve Publisher",
+    icon: "🛡️",
+    type: "cron",
+    category: "publishing",
+    description:
+      "Daily safety net. At 9pm UTC, checks if each site published 1 EN + 1 AR article today. If not, generates and publishes from reservoir or scratch. Guarantees daily minimums.",
+    feedsInto: "SEO Deep Review",
+  },
+  {
+    path: "/api/cron/seo-deep-review",
+    schedule: "0 0 * * *",
+    label: "SEO Deep Review",
+    icon: "🔬",
+    type: "cron",
+    category: "seo",
+    description:
+      "3 hours after reserve-publisher. ACTIVELY FIXES every SEO dimension on articles published today: meta, links, headings, content expansion, affiliate injection, alt text, then resubmits to IndexNow.",
+    feedsInto: "IndexNow",
+  },
+  {
+    path: "/api/cron/fact-verification",
+    schedule: "0 3 * * 0",
+    label: "Fact Verification",
+    icon: "🔬",
+    type: "cron",
+    category: "content",
+    description: "Weekly fact-check pass on generated content. Flags suspicious claims and verifies key data points.",
+  },
+  {
+    path: "/api/cron/campaign-executor",
+    schedule: "12,42 * * * *",
+    label: "Campaign Agent",
+    icon: "🎯",
+    type: "cron",
+    category: "content",
+    description:
+      "Processes active campaign batches. Enhances published articles, injects affiliates, fixes headings, expands Arabic content. 2x per hour.",
+    feedsInto: "Published content",
+  },
+  {
+    path: "/api/cron/pipeline-health",
+    schedule: "30 1,7,13,19 * * *",
+    label: "Pipeline Health Monitor",
+    icon: "📋",
+    type: "cron",
+    category: "maintenance",
+    description:
+      "Snapshots pipeline throughput, bottlenecks, active count accuracy, recovery agent conflicts, and AI provider health. Pure observation — never modifies data.",
+  },
+  {
+    path: "/api/cron/perplexity-scheduler",
+    schedule: "10 */2 * * *",
+    label: "Perplexity Scheduler",
+    icon: "🔮",
+    type: "cron",
+    category: "ai",
+    description:
+      "Processes due Perplexity Computer schedules. Creates tasks from templates for recurring research, audits, and monitoring.",
+    feedsInto: "Perplexity Executor",
+  },
+  {
+    path: "/api/cron/perplexity-executor",
+    schedule: "20,50 * * * *",
+    label: "Perplexity Executor",
+    icon: "⚡",
+    type: "cron",
+    category: "ai",
+    description:
+      "Executes ready Perplexity Computer tasks by calling the Perplexity API. Processes up to 5 tasks per run with rate limiting.",
+    feedsInto: "Task Results",
+  },
+  {
+    path: "/api/cron/diagnostic-sweep",
+    schedule: "55 1,3,5,7,9,11,13,15,17,19,21,23 * * *",
+    label: "Diagnostic Sweep",
+    icon: "🔍",
+    type: "cron",
+    category: "maintenance",
+    description: "Runs diagnostic agent to auto-fix stuck drafts, timeout loops, and pipeline blockages every 2 hours.",
+    feedsInto: "AutoFixLog",
+  },
+  {
+    path: "/api/cron/audit-roundup",
+    schedule: "0 7,19 * * *",
+    label: "Audit Roundup",
+    icon: "🎯",
+    type: "cron",
+    category: "maintenance",
+    description:
+      "Twice-daily ROI-ranked auto-fix sweep. Pulls findings from all audit sources, executes top auto-fixable actions within 280s budget.",
+    feedsInto: "AutoFixLog",
+  },
+  {
+    path: "/api/cron/ceo-intelligence",
+    schedule: "50 5 * * 0",
+    label: "CEO Intelligence",
+    icon: "🧠",
+    type: "cron",
+    category: "maintenance",
+    description:
+      "Weekly autonomous intelligence: gathers GA4/GSC metrics, runs cleanup, compares KPIs, generates plans, reviews standards, emails CEO report.",
+    feedsInto: "CEO Email Report",
+  },
+  {
+    path: "/api/cron/data-refresh",
+    schedule: "45 6 * * *",
+    label: "Data Refresh",
+    icon: "🔄",
+    type: "cron",
+    category: "maintenance",
+    description: "Refreshes currency, weather, holidays, and countries caches daily.",
+    feedsInto: "Foundation APIs",
+  },
+  {
+    path: "/api/cron/events-sync",
+    schedule: "45 6 * * 1",
+    label: "Events Sync",
+    icon: "🎫",
+    type: "cron",
+    category: "content",
+    description: "Fetches Ticketmaster events weekly for homepage display.",
+    feedsInto: "Homepage Events",
+  },
+  {
+    path: "/api/cron/image-pipeline",
+    schedule: "20 2,10,18 * * *",
+    label: "Image Pipeline (3x)",
+    icon: "🖼️",
+    type: "cron",
+    category: "content",
+    description: "Stocks media library from Unsplash and assigns featured images to articles.",
+    feedsInto: "MediaAsset",
+  },
+  {
+    path: "/api/cron/process-indexing-queue",
+    schedule: "25 7,13,20 * * *",
+    label: "IndexNow Queue",
+    icon: "📡",
+    type: "cron",
+    category: "seo",
+    description: "Processes pending URLs and submits to IndexNow (Bing, Yandex, api.indexnow.org).",
+    feedsInto: "IndexNow Engines",
+  },
+  {
+    path: "/api/cron/discovery-monitor",
+    schedule: "0 3,9,15,21 * * *",
+    label: "Discovery Monitor",
+    icon: "🔎",
+    type: "cron",
+    category: "seo",
+    description: "Monitors URL discovery and indexing health 4x daily.",
+    feedsInto: "Indexing Dashboard",
+  },
+  {
+    path: "/api/cron/daily-seo-audit",
+    schedule: "20 5 * * *",
+    label: "Daily SEO Audit",
+    icon: "📊",
+    type: "cron",
+    category: "seo",
+    description: "Runs daily SEO audit checks across all published pages.",
+    feedsInto: "SEO Reports",
+  },
+  {
+    path: "/api/cron/agent-maintenance",
+    schedule: "30 6 * * 0",
+    label: "CTO Agent Maintenance",
+    icon: "🔧",
+    type: "cron",
+    category: "maintenance",
+    description:
+      "Weekly CTO Agent maintenance loop: scans codebase, checks cron/pipeline health, researches fixes, proposes improvements.",
+    feedsInto: "AgentTask",
+  },
+  {
+    path: "/api/cron/retention-executor",
+    schedule: "30 0,4,8,12,16,20 * * *",
+    label: "Retention Executor",
+    icon: "📧",
+    type: "cron",
+    category: "email",
+    description:
+      "Sends due retention emails (welcome series, post-booking follow-ups), triggers re-engagement for 30d+ inactive subscribers, seeds default sequences.",
+    feedsInto: "RetentionProgress",
+  },
+  {
+    path: "/api/cron/followup-executor",
+    schedule: "5 1,5,9,13,17,21 * * *",
+    label: "Follow-up Executor",
+    icon: "🔄",
+    type: "cron",
+    category: "agent",
+    description:
+      "Processes due CEO Agent follow-up tasks by re-invoking CEO Brain. Picks up AgentTask records with dueAt <= now.",
+    feedsInto: "AgentTask",
+  },
+  {
+    path: "/api/cron/schedule-executor",
+    schedule: "20 1,3,5,7,9,11,13,15,17,19,21,23 * * *",
+    label: "Schedule Executor",
+    icon: "📅",
+    type: "cron",
+    category: "content",
+    description:
+      "Creates EN+AR draft pairs from ContentScheduleRule every 2h. Seeds default rule on first run. Critical for pipeline throughput.",
+    feedsInto: "Content Builder",
+  },
+  {
+    path: "/api/cron/content-freshness",
+    schedule: "0 10 * * 0",
+    label: "Content Freshness",
+    icon: "🔄",
+    type: "cron",
+    category: "content",
+    description: "Weekly freshness check on published articles. Flags stale content for update or rewrite.",
+  },
+  {
+    path: "/api/cron/seo-audit-runner",
+    schedule: "0 2 * * *",
+    label: "SEO Audit Runner",
+    icon: "📊",
+    type: "cron",
+    category: "seo",
+    description: "Daily automated SEO audit across all published pages. Generates SeoAuditReport records.",
+    feedsInto: "SEO Reports",
+  },
+  {
+    path: "/api/cron/social",
+    schedule: "5 10,15,20 * * *",
+    label: "Social Publisher",
+    icon: "📣",
+    type: "cron",
+    category: "content",
+    description: "Auto-publishes scheduled social posts (Twitter). Flags other platforms as pending manual.",
+    feedsInto: "Social Calendar",
+  },
+  {
+    path: "/api/cron/subscriber-emails",
+    schedule: "10 11 * * *",
+    label: "Subscriber Emails",
+    icon: "📬",
+    type: "cron",
+    category: "email",
+    description: "Sends daily subscriber digest emails. Processes email queue for welcome sequences and newsletters.",
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -130,12 +641,12 @@ function nextFireTime(expr: string, from: Date = new Date()): Date {
 
   // Parse a field into an array of valid values
   function expand(field: string, min: number, max: number): number[] {
-    if (field === '*') return Array.from({ length: max - min + 1 }, (_, i) => i + min);
+    if (field === "*") return Array.from({ length: max - min + 1 }, (_, i) => i + min);
     const vals = new Set<number>();
-    for (const part of field.split(',')) {
-      if (part.includes('/')) {
-        const [rangeStr, step] = part.split('/');
-        const start = rangeStr === '*' ? min : parseInt(rangeStr);
+    for (const part of field.split(",")) {
+      if (part.includes("/")) {
+        const [rangeStr, step] = part.split("/");
+        const start = rangeStr === "*" ? min : parseInt(rangeStr);
         for (let v = start; v <= max; v += parseInt(step)) vals.add(v);
       } else {
         vals.add(parseInt(part));
@@ -145,9 +656,9 @@ function nextFireTime(expr: string, from: Date = new Date()): Date {
   }
 
   const validMins = expand(minExpr, 0, 59);
-  const validHrs  = expand(hrExpr, 0, 23);
-  const validDows = dowExpr === '*' ? [0,1,2,3,4,5,6] : expand(dowExpr, 0, 6);
-  const domWild   = domExpr === '*';
+  const validHrs = expand(hrExpr, 0, 23);
+  const validDows = dowExpr === "*" ? [0, 1, 2, 3, 4, 5, 6] : expand(dowExpr, 0, 6);
+  const domWild = domExpr === "*";
 
   // Walk forward minute-by-minute for up to 8 days
   const candidate = new Date(from);
@@ -157,7 +668,7 @@ function nextFireTime(expr: string, from: Date = new Date()): Date {
   const limit = new Date(from.getTime() + 8 * 24 * 60 * 60 * 1000);
   while (candidate < limit) {
     const dow = candidate.getUTCDay();
-    const hr  = candidate.getUTCHours();
+    const hr = candidate.getUTCHours();
     const min = candidate.getUTCMinutes();
 
     if (!validDows.includes(dow)) {
@@ -204,63 +715,63 @@ function nextFireTime(expr: string, from: Date = new Date()): Date {
 function scheduleLabel(expr: string): string {
   const labels: Record<string, string> = {
     // Analytics & early morning
-    '30 2 * * *': 'Daily 2:30 AM UTC',
-    '0 3,9,15,21 * * *': '4x daily 3,9,15,21 UTC',
-    '0 3 * * 0': 'Sun 3:00 AM UTC',
-    '15 3 * * 0': 'Sun 3:15 AM UTC',
+    "30 2 * * *": "Daily 2:30 AM UTC",
+    "0 3,9,15,21 * * *": "4x daily 3,9,15,21 UTC",
+    "0 3 * * 0": "Sun 3:00 AM UTC",
+    "15 3 * * 0": "Sun 3:15 AM UTC",
     // Topics & sync
-    '10 4 * * *': 'Daily 4:10 AM UTC',
-    '50 4 * * *': 'Daily 4:50 AM UTC',
-    '20 5 * * *': 'Daily 5:20 AM UTC',
-    '30 5 * * *': 'Daily 5:30 AM UTC',
-    '50 5 * * 0': 'Sun 5:50 AM UTC',
+    "10 4 * * *": "Daily 4:10 AM UTC",
+    "50 4 * * *": "Daily 4:50 AM UTC",
+    "20 5 * * *": "Daily 5:20 AM UTC",
+    "30 5 * * *": "Daily 5:30 AM UTC",
+    "50 5 * * 0": "Sun 5:50 AM UTC",
     // SEO & morning crons
-    '10 6 * * *': 'Daily 6:10 AM UTC',
-    '10 6 * * 0': 'Sun 6:10 AM UTC',
-    '30 6 * * *': 'Daily 6:30 AM UTC',
-    '40 6,14 * * *': '2x daily 6:40 & 14:40 UTC',
-    '45 6 * * *': 'Daily 6:45 AM UTC',
-    '45 6 * * 1': 'Mon 6:45 AM UTC',
-    '50 6 * * *': 'Daily 6:50 AM UTC',
-    '0 7 * * *': 'Daily 7:00 AM UTC',
-    '25 7,13,20 * * *': '3x daily 7:25,13:25,20:25 UTC',
-    '30 7 * * *': 'Daily 7:30 AM UTC',
+    "10 6 * * *": "Daily 6:10 AM UTC",
+    "10 6 * * 0": "Sun 6:10 AM UTC",
+    "30 6 * * *": "Daily 6:30 AM UTC",
+    "40 6,14 * * *": "2x daily 6:40 & 14:40 UTC",
+    "45 6 * * *": "Daily 6:45 AM UTC",
+    "45 6 * * 1": "Mon 6:45 AM UTC",
+    "50 6 * * *": "Daily 6:50 AM UTC",
+    "0 7 * * *": "Daily 7:00 AM UTC",
+    "25 7,13,20 * * *": "3x daily 7:25,13:25,20:25 UTC",
+    "30 7 * * *": "Daily 7:30 AM UTC",
     // Content builder & pipeline
-    '8,23,38,53 * * * *': 'Every 15 min (offset)',
-    '7 */1 * * *': 'Hourly at :07',
-    '45 8,14,20 * * *': '3x daily 8:45,14:45,20:45 UTC',
+    "8,23,38,53 * * * *": "Every 15 min (offset)",
+    "7 */1 * * *": "Hourly at :07",
+    "45 8,14,20 * * *": "3x daily 8:45,14:45,20:45 UTC",
     // Publishing & indexing
-    '15 9 * * *': 'Daily 9:15 AM UTC',
-    '15 12 * * *': 'Daily 12:15 PM UTC',
-    '35 9 * * *': 'Daily 9:35 AM UTC',
-    '5 7,9,11,13,15,17,19,21 * * *': '8x daily :05 past even hours',
-    '25 9 * * *': 'Daily 9:25 AM UTC',
-    '0 11,18 * * *': 'Daily 11:00 & 18:00 UTC',
-    '5 11,17 * * *': '2x daily 11:05 & 17:05 UTC',
-    '10 11 * * *': 'Daily 11:10 AM UTC',
+    "15 9 * * *": "Daily 9:15 AM UTC",
+    "15 12 * * *": "Daily 12:15 PM UTC",
+    "35 9 * * *": "Daily 9:35 AM UTC",
+    "5 7,9,11,13,15,17,19,21 * * *": "8x daily :05 past even hours",
+    "25 9 * * *": "Daily 9:25 AM UTC",
+    "0 11,18 * * *": "Daily 11:00 & 18:00 UTC",
+    "5 11,17 * * *": "2x daily 11:05 & 17:05 UTC",
+    "10 11 * * *": "Daily 11:10 AM UTC",
     // Afternoon & evening
-    '0 13 * * *': 'Daily 1:00 PM UTC',
-    '0 14 * * *': 'Daily 2:00 PM UTC',
-    '0 16 * * *': 'Daily 4:00 PM UTC',
-    '0 20 * * *': 'Daily 8:00 PM UTC',
-    '10 21 * * *': 'Daily 9:10 PM UTC',
-    '0 0 * * *': 'Daily midnight UTC',
-    '0 22 * * *': 'Daily 10:00 PM UTC',
-    '0 10 * * 0': 'Sun 10:00 AM UTC',
-    '0 2 * * *': 'Daily 2:00 AM UTC',
-    '5 10,15,20 * * *': '3x daily 10:05,15:05,20:05 UTC',
+    "0 13 * * *": "Daily 1:00 PM UTC",
+    "0 14 * * *": "Daily 2:00 PM UTC",
+    "0 16 * * *": "Daily 4:00 PM UTC",
+    "0 20 * * *": "Daily 8:00 PM UTC",
+    "10 21 * * *": "Daily 9:10 PM UTC",
+    "0 0 * * *": "Daily midnight UTC",
+    "0 22 * * *": "Daily 10:00 PM UTC",
+    "0 10 * * 0": "Sun 10:00 AM UTC",
+    "0 2 * * *": "Daily 2:00 AM UTC",
+    "5 10,15,20 * * *": "3x daily 10:05,15:05,20:05 UTC",
     // High-frequency crons
-    '12,42 * * * *': '2x hourly at :12 & :42',
-    '10 */2 * * *': 'Every 2h at :10',
-    '20,50 * * * *': '2x hourly at :20 & :50',
-    '55 1,3,5,7,9,11,13,15,17,19,21,23 * * *': 'Every 2h at :55 (odd hours)',
-    '20 2,10,18 * * *': '3x daily 2:20,10:20,18:20 UTC',
-    '30 1,7,13,19 * * *': '4x daily 1:30,7:30,13:30,19:30 UTC',
-    '40 0,4,8,12,16,20 * * *': '6x daily :40 every 4h',
-    '30 0,4,8,12,16,20 * * *': '6x daily :30 every 4h',
-    '5 1,5,9,13,17,21 * * *': '6x daily :05 every 4h',
-    '20 1,3,5,7,9,11,13,15,17,19,21,23 * * *': 'Every 2h at :20',
-    '30 6 * * 0': 'Sun 6:30 AM UTC',
+    "12,42 * * * *": "2x hourly at :12 & :42",
+    "10 */2 * * *": "Every 2h at :10",
+    "20,50 * * * *": "2x hourly at :20 & :50",
+    "55 1,3,5,7,9,11,13,15,17,19,21,23 * * *": "Every 2h at :55 (odd hours)",
+    "20 2,10,18 * * *": "3x daily 2:20,10:20,18:20 UTC",
+    "30 1,7,13,19 * * *": "4x daily 1:30,7:30,13:30,19:30 UTC",
+    "40 0,4,8,12,16,20 * * *": "6x daily :40 every 4h",
+    "30 0,4,8,12,16,20 * * *": "6x daily :30 every 4h",
+    "5 1,5,9,13,17,21 * * *": "6x daily :05 every 4h",
+    "20 1,3,5,7,9,11,13,15,17,19,21,23 * * *": "Every 2h at :20",
+    "30 6 * * 0": "Sun 6:30 AM UTC",
   };
   return labels[expr] ?? expr;
 }
@@ -275,17 +786,15 @@ export async function GET(req: NextRequest) {
 
   const siteId = req.nextUrl.searchParams.get("siteId") || getDefaultSiteId();
 
-  const { prisma } = await import('@/lib/db');
+  const { prisma } = await import("@/lib/db");
   const now = new Date();
   const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
 
   // Fetch 7 days of logs for success rate + last run info
-  const cronSiteFilter = siteId && siteId !== "all"
-    ? { OR: [{ site_id: siteId }, { site_id: null }] }
-    : {};
+  const cronSiteFilter = siteId && siteId !== "all" ? { OR: [{ site_id: siteId }, { site_id: null }] } : {};
   const recentLogs = await prisma.cronJobLog.findMany({
     where: { started_at: { gte: sevenDaysAgo }, ...cronSiteFilter },
-    orderBy: { started_at: 'desc' },
+    orderBy: { started_at: "desc" },
     select: { job_name: true, status: true, started_at: true, duration_ms: true, error_message: true },
     take: 1000,
   });
@@ -299,7 +808,7 @@ export async function GET(req: NextRequest) {
     }
     const prev = statsMap.get(log.job_name) ?? { total: 0, success: 0, durations: [] };
     prev.total++;
-    if (log.status === 'success' || log.status === 'completed') prev.success++;
+    if (log.status === "success" || log.status === "completed") prev.success++;
     if (log.duration_ms) prev.durations.push(log.duration_ms);
     statsMap.set(log.job_name, prev);
   }
@@ -307,7 +816,7 @@ export async function GET(req: NextRequest) {
   // Derive job name from cron path, resolving aliases for affiliate/orchestrator crons
   const { resolveCronAlias } = await import("@/lib/cron-feature-guard");
   function jobName(path: string): string {
-    const raw = path.split('/').pop()?.split('?')[0] ?? path;
+    const raw = path.split("/").pop()?.split("?")[0] ?? path;
     return resolveCronAlias(raw);
   }
 
@@ -328,22 +837,24 @@ export async function GET(req: NextRequest) {
 
     // 7-day stats
     const stats = statsMap.get(name) ?? statsMap.get(def.path);
-    const successRate = stats && stats.total > 0
-      ? Math.round((stats.success / stats.total) * 100)
-      : null;
-    const avgDuration = stats && stats.durations.length > 0
-      ? Math.round(stats.durations.reduce((a, b) => a + b, 0) / stats.durations.length)
-      : null;
+    const successRate = stats && stats.total > 0 ? Math.round((stats.success / stats.total) * 100) : null;
+    const avgDuration =
+      stats && stats.durations.length > 0
+        ? Math.round(stats.durations.reduce((a, b) => a + b, 0) / stats.durations.length)
+        : null;
 
     // Plain-English error from last failure
     let lastError: string | null = null;
-    if (lastRun?.status !== 'success' && lastRun?.status !== 'completed' && lastRun?.error) {
+    if (lastRun?.status !== "success" && lastRun?.status !== "completed" && lastRun?.error) {
       try {
-        const { interpretError } = await import('@/lib/error-interpreter');
+        const { interpretError } = await import("@/lib/error-interpreter");
         const interpreted = interpretError(lastRun.error);
         lastError = interpreted.plain;
       } catch (interpErr) {
-        console.warn('[departures] interpretError import failed:', interpErr instanceof Error ? interpErr.message : String(interpErr));
+        console.warn(
+          "[departures] interpretError import failed:",
+          interpErr instanceof Error ? interpErr.message : String(interpErr),
+        );
         lastError = lastRun.error.slice(0, 120);
       }
     }
@@ -351,15 +862,19 @@ export async function GET(req: NextRequest) {
     departures.push({
       id: `cron::${dedupeKey}`,
       label: def.label,
-      type: 'cron',
+      type: "cron",
       icon: def.icon,
       scheduledAt: fireAt.toISOString(),
       countdownMs: countdown,
-      status: countdown < 0 ? 'overdue' : 'scheduled',
+      status: countdown < 0 ? "overdue" : "scheduled",
       cronPath: def.path,
       cronSchedule: scheduleLabel(def.schedule),
       lastRunAt: lastRun?.at.toISOString() ?? null,
-      lastRunStatus: lastRun ? (lastRun.status === 'success' || lastRun.status === 'completed' ? 'success' : 'failed') : 'unknown',
+      lastRunStatus: lastRun
+        ? lastRun.status === "success" || lastRun.status === "completed"
+          ? "success"
+          : "failed"
+        : "unknown",
       siteId: null,
       description: def.description,
       category: def.category,
@@ -375,11 +890,11 @@ export async function GET(req: NextRequest) {
     const activeSiteIds = getActiveSiteIds();
     const scheduled = await prisma.scheduledContent.findMany({
       where: {
-        status: { in: ['scheduled', 'pending'] },
+        status: { in: ["scheduled", "pending"] },
         scheduled_time: { gte: now },
         site_id: { in: activeSiteIds },
       },
-      orderBy: { scheduled_time: 'asc' },
+      orderBy: { scheduled_time: "asc" },
       take: 20,
       select: {
         id: true,
@@ -394,21 +909,22 @@ export async function GET(req: NextRequest) {
       const fireAt = sc.scheduled_time ?? new Date(now.getTime() + 999 * 60_000);
       departures.push({
         id: `pub::${sc.id}`,
-        label: sc.title ?? 'Scheduled Publication',
-        type: 'publication',
-        icon: '📄',
+        label: sc.title ?? "Scheduled Publication",
+        type: "publication",
+        icon: "📄",
         scheduledAt: fireAt.toISOString(),
         countdownMs: fireAt.getTime() - now.getTime(),
-        status: 'scheduled',
-        cronPath: '/api/cron/scheduled-publish',
-        cronSchedule: fireAt.toLocaleString('en-GB', { timeZone: 'UTC', hour12: false }),
+        status: "scheduled",
+        cronPath: "/api/cron/scheduled-publish",
+        cronSchedule: fireAt.toLocaleString("en-GB", { timeZone: "UTC", hour12: false }),
         lastRunAt: null,
         lastRunStatus: null,
         siteId: sc.site_id ?? null,
-        meta: { contentType: sc.content_type ?? 'article' },
-        description: 'Scheduled article awaiting its publish time. Will pass the 14-check pre-publication gate before going live.',
-        category: 'publishing',
-        feedsInto: 'SEO Agent',
+        meta: { contentType: sc.content_type ?? "article" },
+        description:
+          "Scheduled article awaiting its publish time. Will pass the 14-check pre-publication gate before going live.",
+        category: "publishing",
+        feedsInto: "SEO Agent",
         successRate7d: null,
         avgDurationMs: null,
         lastError: null,
@@ -422,31 +938,32 @@ export async function GET(req: NextRequest) {
   try {
     const activeSiteIds = getActiveSiteIds();
     const reservoir = await prisma.articleDraft.findMany({
-      where: { current_phase: 'reservoir', site_id: { in: activeSiteIds } },
-      orderBy: { updated_at: 'desc' },
+      where: { current_phase: "reservoir", site_id: { in: activeSiteIds } },
+      orderBy: { updated_at: "desc" },
       take: 5,
       select: { id: true, keyword: true, quality_score: true, site_id: true },
     });
     for (const d of reservoir) {
       // Next content-selector run = closest of 9,13,17,21 UTC today
-      const selectorNext = nextFireTime('0 9,13,17,21 * * *', now);
+      const selectorNext = nextFireTime("0 9,13,17,21 * * *", now);
       departures.push({
         id: `reservoir::${d.id}`,
-        label: `Publish: ${d.keyword?.slice(0, 50) ?? 'Article'}`,
-        type: 'content',
-        icon: '✅',
+        label: `Publish: ${d.keyword?.slice(0, 50) ?? "Article"}`,
+        type: "content",
+        icon: "✅",
         scheduledAt: selectorNext.toISOString(),
         countdownMs: selectorNext.getTime() - now.getTime(),
-        status: 'ready',
-        cronPath: '/api/cron/content-selector',
-        cronSchedule: 'Next content-selector run',
+        status: "ready",
+        cronPath: "/api/cron/content-selector",
+        cronSchedule: "Next content-selector run",
         lastRunAt: null,
         lastRunStatus: null,
         siteId: d.site_id,
         meta: { qualityScore: d.quality_score ?? 0 },
-        description: 'Article ready in the reservoir — highest quality score articles are published first by the content selector.',
-        category: 'publishing',
-        feedsInto: 'Published content → SEO Agent',
+        description:
+          "Article ready in the reservoir — highest quality score articles are published first by the content selector.",
+        category: "publishing",
+        feedsInto: "Published content → SEO Agent",
         successRate7d: null,
         avgDurationMs: null,
         lastError: null,
@@ -458,8 +975,8 @@ export async function GET(req: NextRequest) {
 
   // Sort all departures: overdue first, then by countdown ascending
   departures.sort((a, b) => {
-    if (a.status === 'overdue' && b.status !== 'overdue') return -1;
-    if (b.status === 'overdue' && a.status !== 'overdue') return 1;
+    if (a.status === "overdue" && b.status !== "overdue") return -1;
+    if (b.status === "overdue" && a.status !== "overdue") return 1;
     if (a.countdownMs === null) return 1;
     if (b.countdownMs === null) return -1;
     return a.countdownMs - b.countdownMs;
@@ -475,8 +992,8 @@ export async function GET(req: NextRequest) {
     departures,
     generatedAt: now.toISOString(),
     totalCrons: CRON_DEFS.length,
-    totalPublications: departures.filter((d) => d.type === 'publication').length,
-    totalReady: departures.filter((d) => d.status === 'ready').length,
+    totalPublications: departures.filter((d) => d.type === "publication").length,
+    totalReady: departures.filter((d) => d.status === "ready").length,
     categories,
     siteId,
   });
@@ -494,18 +1011,20 @@ export async function POST(req: NextRequest) {
   // Accept both "cronPath" (departures board) and "path" (cockpit GSC sync button)
   const cronPath = (body as Record<string, string>).cronPath || (body as Record<string, string>).path;
 
-  if (!cronPath || !cronPath.startsWith('/api/')) {
-    return NextResponse.json({ error: 'Invalid cronPath' }, { status: 400 });
+  if (!cronPath || !cronPath.startsWith("/api/")) {
+    return NextResponse.json({ error: "Invalid cronPath" }, { status: 400 });
   }
 
   // Validate against known cron paths only
   const knownPaths = new Set(CRON_DEFS.map((d) => d.path));
-  const basePath = cronPath.split('?')[0];
-  const isKnown = knownPaths.has(cronPath) || knownPaths.has(basePath) ||
-    Array.from(knownPaths).some((p) => p.split('?')[0] === basePath);
+  const basePath = cronPath.split("?")[0];
+  const isKnown =
+    knownPaths.has(cronPath) ||
+    knownPaths.has(basePath) ||
+    Array.from(knownPaths).some((p) => p.split("?")[0] === basePath);
 
   if (!isKnown) {
-    return NextResponse.json({ error: 'Unknown cron path' }, { status: 400 });
+    return NextResponse.json({ error: "Unknown cron path" }, { status: 400 });
   }
 
   // Trigger the cron by calling it as an internal POST request
@@ -514,20 +1033,35 @@ export async function POST(req: NextRequest) {
 
   try {
     const triggerRes = await fetch(targetUrl, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         // Pass through the cron secret if configured
         ...(process.env.CRON_SECRET ? { Authorization: `Bearer ${process.env.CRON_SECRET}` } : {}),
       },
       signal: AbortSignal.timeout(305_000), // Must be > longest cron maxDuration (300s) to avoid premature abort
     });
 
-    const text = await triggerRes.text().catch(() => '');
+    const text = await triggerRes.text().catch(() => "");
     let result: unknown;
-    try { result = JSON.parse(text); } catch { result = text.slice(0, 200); }
+    try {
+      result = JSON.parse(text);
+    } catch {
+      result = text.slice(0, 200);
+    }
 
-    logManualAction(req, { action: "do-now", resource: "cron", resourceId: cronPath, success: triggerRes.ok, summary: triggerRes.ok ? `Triggered ${cronPath} (${triggerRes.status})` : `Trigger ${cronPath} returned ${triggerRes.status}`, error: !triggerRes.ok ? `HTTP ${triggerRes.status}` : undefined, fix: !triggerRes.ok ? "Check cron endpoint logs and AI/DB connectivity." : undefined, details: { path: cronPath, statusCode: triggerRes.status } }).catch(() => {});
+    logManualAction(req, {
+      action: "do-now",
+      resource: "cron",
+      resourceId: cronPath,
+      success: triggerRes.ok,
+      summary: triggerRes.ok
+        ? `Triggered ${cronPath} (${triggerRes.status})`
+        : `Trigger ${cronPath} returned ${triggerRes.status}`,
+      error: !triggerRes.ok ? `HTTP ${triggerRes.status}` : undefined,
+      fix: !triggerRes.ok ? "Check cron endpoint logs and AI/DB connectivity." : undefined,
+      details: { path: cronPath, statusCode: triggerRes.status },
+    }).catch(() => {});
 
     return NextResponse.json({
       triggered: true,
@@ -536,11 +1070,16 @@ export async function POST(req: NextRequest) {
       result,
     });
   } catch (err) {
-    const errMsg = err instanceof Error ? err.message : 'Unknown error';
-    logManualAction(req, { action: "do-now", resource: "cron", resourceId: cronPath, success: false, summary: `Trigger ${cronPath} crashed`, error: errMsg, fix: "Cron endpoint may be timing out or the server is unreachable." }).catch(() => {});
-    return NextResponse.json(
-      { triggered: false, error: errMsg },
-      { status: 500 }
-    );
+    const errMsg = err instanceof Error ? err.message : "Unknown error";
+    logManualAction(req, {
+      action: "do-now",
+      resource: "cron",
+      resourceId: cronPath,
+      success: false,
+      summary: `Trigger ${cronPath} crashed`,
+      error: errMsg,
+      fix: "Cron endpoint may be timing out or the server is unreachable.",
+    }).catch(() => {});
+    return NextResponse.json({ triggered: false, error: errMsg }, { status: 500 });
   }
 }

--- a/yalla_london/app/app/api/admin/public-audit/route.ts
+++ b/yalla_london/app/app/api/admin/public-audit/route.ts
@@ -905,6 +905,272 @@ function auditAioAlignment(posts: ArticleRow[]): DimensionResult {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
+// Dimension 6: Affiliate practices (FTC compliance + on-page hygiene)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// Bundles three Tier-2 blind spots:
+//   - rel + disclosure + anchor variety        (per-article hygiene)
+//   - Dead CJ programs                         (cross-ref CjAdvertiser status)
+//   - Anchor-text concentration                (sitewide over-optimization)
+//
+// Outbound link health (#12) is HTTP-bound and lives in Batch 8 where we have
+// async execution budget. The static signals we collect here are accurate
+// enough to guide most fixes.
+
+const AFFILIATE_PARTNER_HOSTS = [
+  "anrdoezrs.net",
+  "tkqlhce.com",
+  "jdoqocy.com",
+  "kqzyfj.com",
+  "click.linksynergy.com",
+  "stay22.com",
+  "letmeallez.com",
+  "tp.media",
+  "tp-em.com",
+  "travelpayouts.com",
+  "booking.com",
+  "vrbo.com",
+  "expedia.com",
+  "agoda.com",
+  "hotellook.com",
+  "getyourguide.com",
+  "viator.com",
+  "klook.com",
+  "tiqets.com",
+];
+
+const DISCLOSURE_HINT_PATTERNS = [
+  /\baffiliate\s+(?:link|disclosure)\b/i,
+  /\bcommission\b/i,
+  /\bearn\s+(?:a|small)\s+commission\b/i,
+  /\bpartner\s+with\b/i,
+  /\bdisclosure\b/i,
+];
+
+const GENERIC_ANCHOR_TEXT = [
+  /^click here$/i,
+  /^this link$/i,
+  /^check it out$/i,
+  /^learn more$/i,
+  /^read more$/i,
+  /^here$/i,
+  /^link$/i,
+  /^website$/i,
+];
+
+interface AffiliateLinkRef {
+  href: string;
+  hostname: string;
+  rel: string;
+  anchorText: string;
+  isAffiliate: boolean;
+  isAffiliateClickRedirect: boolean;
+}
+
+function extractLinks(content: string): AffiliateLinkRef[] {
+  const out: AffiliateLinkRef[] = [];
+  const anchorRe = /<a\s+([^>]*?)>([\s\S]*?)<\/a>/gi;
+  for (const m of content.matchAll(anchorRe)) {
+    const attrs = m[1] || "";
+    const inner = stripHtml(m[2] || "").trim();
+    const hrefMatch = /\bhref\s*=\s*"([^"]+)"/i.exec(attrs);
+    const relMatch = /\brel\s*=\s*"([^"]+)"/i.exec(attrs);
+    if (!hrefMatch) continue;
+    const href = hrefMatch[1];
+    let hostname = "";
+    let isAffiliateClickRedirect = false;
+    try {
+      // Allow relative URLs to be detected as affiliate-click redirects too.
+      if (href.startsWith("/api/affiliate/click")) {
+        isAffiliateClickRedirect = true;
+        hostname = "internal";
+      } else {
+        const u = new URL(href);
+        hostname = u.hostname.toLowerCase().replace(/^www\./, "");
+      }
+    } catch {
+      continue;
+    }
+    const isAffiliate = isAffiliateClickRedirect || AFFILIATE_PARTNER_HOSTS.some((h) => hostname.includes(h));
+    out.push({
+      href,
+      hostname,
+      rel: relMatch ? relMatch[1] : "",
+      anchorText: inner,
+      isAffiliate,
+      isAffiliateClickRedirect,
+    });
+  }
+  return out;
+}
+
+interface DeadAdvertiserSet {
+  // Lowercased advertiser names whose CJ status is DECLINED, CANCELLED, etc.
+  names: Set<string>;
+  // Lowercased advertiser hostnames (programUrl host) for the same.
+  hostnames: Set<string>;
+}
+
+async function loadDeadAdvertisers(): Promise<DeadAdvertiserSet> {
+  const dead: DeadAdvertiserSet = {
+    names: new Set<string>(),
+    hostnames: new Set<string>(),
+  };
+  try {
+    const advertisers = await prisma.cjAdvertiser.findMany({
+      where: { status: { in: ["DECLINED", "CANCELLED", "REMOVED"] } },
+      select: { name: true, programUrl: true },
+      take: 500,
+    });
+    for (const a of advertisers) {
+      if (a.name) dead.names.add(a.name.toLowerCase().trim());
+      if (a.programUrl) {
+        try {
+          const u = new URL(a.programUrl);
+          dead.hostnames.add(u.hostname.toLowerCase().replace(/^www\./, ""));
+        } catch {
+          /* not a URL — name match still works */
+        }
+      }
+    }
+  } catch {
+    // CJ tables may not exist on every site or migration may be pending. Don't
+    // crash the audit — return an empty set and let the caller carry on.
+  }
+  return dead;
+}
+
+function auditAffiliatePractices(posts: ArticleRow[], dead: DeadAdvertiserSet): DimensionResult {
+  const issues: Issue[] = [];
+  const bySeverity: Record<Severity, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+  };
+
+  // Sitewide anchor-concentration map: "anchor text → href" → article slugs.
+  // Anything > 10 articles using the same anchor for the same href is an
+  // over-optimization signal Google's spam team flags.
+  const anchorMap = new Map<string, string[]>();
+
+  for (const p of posts) {
+    const slug = p.slug;
+    const title = (p.title_en || "").slice(0, 80);
+    const content = p.content_en || "";
+    const links = extractLinks(content);
+    const affiliateLinks = links.filter((l) => l.isAffiliate);
+    const partners = new Set<string>();
+
+    for (const link of affiliateLinks) {
+      partners.add(link.hostname);
+
+      // Per-article: rel attribute compliance.
+      const rel = link.rel.toLowerCase();
+      if (!link.isAffiliateClickRedirect && !(rel.includes("sponsored") && rel.includes("noopener"))) {
+        pushIssue(issues, bySeverity, {
+          slug,
+          title,
+          severity: "high",
+          detail: `Affiliate link to ${link.hostname} missing rel="noopener sponsored" (FTC + SEO)`,
+        });
+      }
+
+      // Per-article: generic anchor text ("click here").
+      if (link.anchorText && GENERIC_ANCHOR_TEXT.some((re) => re.test(link.anchorText))) {
+        pushIssue(issues, bySeverity, {
+          slug,
+          title,
+          severity: "medium",
+          detail: `Generic anchor "${link.anchorText}" on affiliate link — descriptive anchor text helps both SEO and conversion`,
+        });
+      }
+
+      // Sitewide: feed the anchor concentration map.
+      const anchorKey = `${link.anchorText.toLowerCase().trim()}|${link.href}`;
+      if (link.anchorText.length > 0 && link.anchorText.length < 80) {
+        const existing = anchorMap.get(anchorKey) || [];
+        existing.push(slug);
+        anchorMap.set(anchorKey, existing);
+      }
+
+      // Per-article: dead CJ program cross-ref.
+      const dataAdvertiserMatch = /\bdata-advertiser\s*=\s*"([^"]+)"/i.exec(
+        content.slice(content.indexOf(link.href) - 200, content.indexOf(link.href) + 400),
+      );
+      const advertiserName = dataAdvertiserMatch?.[1]?.toLowerCase().trim();
+      if (advertiserName && dead.names.has(advertiserName)) {
+        pushIssue(issues, bySeverity, {
+          slug,
+          title,
+          severity: "critical",
+          detail: `Affiliate link to "${advertiserName}" — CJ program is DECLINED/CANCELLED, link earns $0`,
+        });
+      } else if (dead.hostnames.has(link.hostname)) {
+        pushIssue(issues, bySeverity, {
+          slug,
+          title,
+          severity: "critical",
+          detail: `Affiliate link to ${link.hostname} — partner program is dead, link earns $0`,
+        });
+      }
+    }
+
+    // Per-article: disclosure paragraph required when affiliates present.
+    if (affiliateLinks.length > 0) {
+      const hasDisclosure = DISCLOSURE_HINT_PATTERNS.some((re) => re.test(content));
+      if (!hasDisclosure) {
+        pushIssue(issues, bySeverity, {
+          slug,
+          title,
+          severity: "critical",
+          detail: `${affiliateLinks.length} affiliate link(s) but no disclosure paragraph (FTC violation)`,
+        });
+      }
+    }
+
+    // Per-article: single-partner concentration (>80% from same partner).
+    if (affiliateLinks.length >= 5 && partners.size === 1) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "low",
+        detail: `${affiliateLinks.length} affiliate links all to ${[...partners][0]} — diversify partners for resilience`,
+      });
+    }
+  }
+
+  // Sitewide anchor concentration check (#7).
+  for (const [anchorKey, slugs] of anchorMap) {
+    if (slugs.length < 10) continue;
+    const [anchorText, href] = anchorKey.split("|");
+    const sample = slugs.slice(0, 5).join(", ");
+    pushIssue(issues, bySeverity, {
+      slug: slugs[0],
+      title: anchorText,
+      severity: "high",
+      detail: `Anchor "${anchorText}" used ${slugs.length}x pointing to ${href} — over-optimization risk. Affected: ${sample}${slugs.length > 5 ? "..." : ""}`,
+    });
+  }
+
+  return {
+    name: "affiliatePractices",
+    score: scoreFromIssues(bySeverity),
+    issuesCount: issues.length,
+    bySeverity,
+    top: topIssues(issues, 15),
+    nextAction:
+      bySeverity.critical > 0
+        ? "Run affiliate_link_health MCP tool — confirms dead programs. Run affiliate-injection cron to swap dead links to live partners. Add disclosure paragraph via content-auto-fix or template update."
+        : bySeverity.high > 0
+          ? "Run seo-agent or affiliate-injection — fixes rel attributes in batch. Diversify anchor text via manual edits."
+          : bySeverity.medium > 0
+            ? "Manual: rewrite generic anchor text to descriptive keyphrases on the affected articles."
+            : "Affiliate practices look clean",
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
 // Handler
 // ───────────────────────────────────────────────────────────────────────────
 
@@ -941,7 +1207,10 @@ export async function GET(request: NextRequest) {
       take: Math.min(Math.max(sample, 50), 1000),
     })) as ArticleRow[];
 
-    const sitewide = buildSitewideContext(posts);
+    const [sitewide, deadAdvertisers] = await Promise.all([
+      Promise.resolve(buildSitewideContext(posts)),
+      loadDeadAdvertisers(),
+    ]);
 
     const dimensions: Record<string, DimensionResult> = {
       photos: auditPhotos(posts),
@@ -949,7 +1218,7 @@ export async function GET(request: NextRequest) {
       newsRefresh: auditNewsRefresh(posts),
       seoUpdates: auditSeoUpdates(posts, sitewide),
       aioAlignment: auditAioAlignment(posts),
-      affiliatePractices: emptyDimension("affiliatePractices", "Pending — Batch 4"),
+      affiliatePractices: auditAffiliatePractices(posts, deadAdvertisers),
     };
 
     return NextResponse.json({

--- a/yalla_london/app/app/api/admin/public-audit/route.ts
+++ b/yalla_london/app/app/api/admin/public-audit/route.ts
@@ -1183,54 +1183,11 @@ export async function GET(request: NextRequest) {
   const sample = parseInt(request.nextUrl.searchParams.get("sample") || "500", 10);
 
   try {
-    const posts = (await prisma.blogPost.findMany({
-      where: { siteId, published: true },
-      select: {
-        id: true,
-        slug: true,
-        siteId: true,
-        title_en: true,
-        title_ar: true,
-        meta_title_en: true,
-        meta_title_ar: true,
-        meta_description_en: true,
-        meta_description_ar: true,
-        content_en: true,
-        content_ar: true,
-        featured_image: true,
-        category_id: true,
-        canonical_slug: true,
-        created_at: true,
-        updated_at: true,
-      },
-      orderBy: { created_at: "desc" },
-      take: Math.min(Math.max(sample, 50), 1000),
-    })) as ArticleRow[];
-
-    const [sitewide, deadAdvertisers] = await Promise.all([
-      Promise.resolve(buildSitewideContext(posts)),
-      loadDeadAdvertisers(),
-    ]);
-
-    const dimensions: Record<string, DimensionResult> = {
-      photos: auditPhotos(posts),
-      unedited: auditUnedited(posts),
-      newsRefresh: auditNewsRefresh(posts),
-      seoUpdates: auditSeoUpdates(posts, sitewide),
-      aioAlignment: auditAioAlignment(posts),
-      affiliatePractices: auditAffiliatePractices(posts, deadAdvertisers),
-    };
-
+    const result = await runPublicAudit(siteId, sample);
     return NextResponse.json({
       success: true,
-      site: siteId,
-      generatedAt: new Date().toISOString(),
+      ...result,
       durationMs: Date.now() - start,
-      totalArticlesScanned: posts.length,
-      dimensions,
-      _format: "yalla-public-audit-v1",
-      _note:
-        "Batch 1 of 5 — only the photos dimension is implemented. The other 5 dimensions return empty placeholders so the response shape stays stable.",
     });
   } catch (err: unknown) {
     return NextResponse.json(
@@ -1241,4 +1198,118 @@ export async function GET(request: NextRequest) {
       { status: 500 },
     );
   }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Public exports — used by the route above AND the platform-control MCP
+// (`public_audit` tool) so both surfaces produce identical reports without
+// HTTP round-tripping.
+// ───────────────────────────────────────────────────────────────────────────
+
+export interface PublicAuditReport {
+  site: string;
+  generatedAt: string;
+  totalArticlesScanned: number;
+  overallScore: number;
+  overallGrade: "A" | "B" | "C" | "D" | "F";
+  topActions: Array<{
+    dimension: string;
+    severity: Severity;
+    detail: string;
+    affectedSlug: string;
+    nextAction: string;
+  }>;
+  plainLanguageSummary: string;
+  dimensions: Record<string, DimensionResult>;
+  _format: "yalla-public-audit-v1";
+}
+
+export async function runPublicAudit(siteId: string, sample = 500): Promise<PublicAuditReport> {
+  const posts = (await prisma.blogPost.findMany({
+    where: { siteId, published: true },
+    select: {
+      id: true,
+      slug: true,
+      siteId: true,
+      title_en: true,
+      title_ar: true,
+      meta_title_en: true,
+      meta_title_ar: true,
+      meta_description_en: true,
+      meta_description_ar: true,
+      content_en: true,
+      content_ar: true,
+      featured_image: true,
+      category_id: true,
+      canonical_slug: true,
+      created_at: true,
+      updated_at: true,
+    },
+    orderBy: { created_at: "desc" },
+    take: Math.min(Math.max(sample, 50), 1000),
+  })) as ArticleRow[];
+
+  const [sitewide, deadAdvertisers] = await Promise.all([
+    Promise.resolve(buildSitewideContext(posts)),
+    loadDeadAdvertisers(),
+  ]);
+
+  const dimensions: Record<string, DimensionResult> = {
+    photos: auditPhotos(posts),
+    unedited: auditUnedited(posts),
+    newsRefresh: auditNewsRefresh(posts),
+    seoUpdates: auditSeoUpdates(posts, sitewide),
+    aioAlignment: auditAioAlignment(posts),
+    affiliatePractices: auditAffiliatePractices(posts, deadAdvertisers),
+  };
+
+  // Overall score: simple average of the 6 dimension scores. Equal weighting
+  // because each dimension represents a distinct failure mode — one bad
+  // dimension shouldn't be drowned out by 5 good ones.
+  const dimList = Object.values(dimensions);
+  const overallScore = Math.round(dimList.reduce((sum, d) => sum + d.score, 0) / dimList.length);
+  const overallGrade: PublicAuditReport["overallGrade"] =
+    overallScore >= 90 ? "A" : overallScore >= 80 ? "B" : overallScore >= 70 ? "C" : overallScore >= 60 ? "D" : "F";
+
+  // Top actions: take the highest-severity issue from each dimension that has
+  // criticals or highs, ranked by severity. Caps at 12 so the surfacing
+  // surface stays scannable on a phone.
+  const sevOrder: Record<Severity, number> = { critical: 0, high: 1, medium: 2, low: 3 };
+  const topActions: PublicAuditReport["topActions"] = [];
+  for (const [name, dim] of Object.entries(dimensions)) {
+    for (const issue of dim.top) {
+      if (issue.severity !== "critical" && issue.severity !== "high") continue;
+      topActions.push({
+        dimension: name,
+        severity: issue.severity,
+        detail: issue.detail,
+        affectedSlug: issue.slug,
+        nextAction: dim.nextAction,
+      });
+    }
+  }
+  topActions.sort((a, b) => sevOrder[a.severity] - sevOrder[b.severity]);
+  const cappedActions = topActions.slice(0, 12);
+
+  // Plain-language summary for the iPhone view.
+  const totalCritical = dimList.reduce((s, d) => s + d.bySeverity.critical, 0);
+  const totalHigh = dimList.reduce((s, d) => s + d.bySeverity.high, 0);
+  const worst = dimList.reduce((a, b) => (a.score < b.score ? a : b));
+  const best = dimList.reduce((a, b) => (a.score > b.score ? a : b));
+  const plainLanguageSummary =
+    totalCritical === 0 && totalHigh === 0
+      ? `Site looks healthy across all 6 dimensions. Overall grade ${overallGrade} (${overallScore}/100). Best: ${best.name}. No critical or high issues found.`
+      : `Overall grade ${overallGrade} (${overallScore}/100). ${totalCritical} critical and ${totalHigh} high-severity issues across ${posts.length} published articles. Worst dimension: ${worst.name} (${worst.score}/100). Top action: ${cappedActions[0]?.nextAction || "No fixes available"}.`;
+
+  return {
+    site: siteId,
+    generatedAt: new Date().toISOString(),
+    totalArticlesScanned: posts.length,
+    overallScore,
+    overallGrade,
+    topActions: cappedActions,
+    plainLanguageSummary,
+    dimensions,
+    _format: "yalla-public-audit-v1",
+  };
 }

--- a/yalla_london/app/app/api/admin/public-audit/route.ts
+++ b/yalla_london/app/app/api/admin/public-audit/route.ts
@@ -189,6 +189,253 @@ function auditPhotos(posts: ArticleRow[]): DimensionResult {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
+// Dimension 2: Unedited content (AI artifacts that leaked into published copy)
+// ───────────────────────────────────────────────────────────────────────────
+
+// Patterns the AI sometimes prefixes/leaks into TITLE or META fields. These
+// must never reach a real reader.
+const TITLE_LEAK_PREFIX = /^(title|meta\s*title|meta\s*description|seo\s*title|h1|heading)\s*:\s*/i;
+const PARENTHETICAL_LENGTH_NOTE = /\(\s*(?:under\s+\d+|\d+\s*(?:chars?|characters?))\b[^)]*\)/i;
+
+// Placeholder / stub markers that should have been cleaned before publish.
+const PLACEHOLDER_MARKERS =
+  /\[(?:TODO|PLACEHOLDER|REDIRECTED|DUPLICATE-FLAGGED|PENDING|FIXME|TBD)\]|TOPIC_SLUG|<<<.*?>>>|XXXTODOXXX/i;
+
+// Markdown that escaped the renderer and printed as literal text.
+const MARKDOWN_LEAK = /```|~~~/;
+
+// Generic AI phrases — Google demotes these per the Jan 2026 Authenticity
+// Update. Each instance is low-severity by itself; the count matters.
+const AI_GENERIC_PHRASES = [
+  "in conclusion",
+  "it's worth noting",
+  "without further ado",
+  "look no further",
+  "nestled in the heart of",
+  "in this comprehensive guide",
+  "whether you're a",
+  "stands as a testament",
+  "embark on a journey",
+];
+
+function auditUnedited(posts: ArticleRow[]): DimensionResult {
+  const issues: Issue[] = [];
+  const bySeverity: Record<Severity, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+  };
+
+  for (const p of posts) {
+    const slug = p.slug;
+    const title = (p.title_en || "").slice(0, 80);
+
+    // Check every visible-to-reader text field for leaks.
+    const textFields: Array<{ name: string; value: string }> = [
+      { name: "title_en", value: p.title_en || "" },
+      { name: "title_ar", value: p.title_ar || "" },
+      { name: "meta_title_en", value: p.meta_title_en || "" },
+      { name: "meta_title_ar", value: p.meta_title_ar || "" },
+      { name: "meta_description_en", value: p.meta_description_en || "" },
+      { name: "meta_description_ar", value: p.meta_description_ar || "" },
+    ];
+
+    for (const f of textFields) {
+      if (!f.value) continue;
+      if (TITLE_LEAK_PREFIX.test(f.value)) {
+        pushIssue(issues, bySeverity, {
+          slug,
+          title,
+          severity: "critical",
+          detail: `${f.name} starts with AI prefix ("${f.value.slice(0, 40)}...")`,
+        });
+      }
+      if (PARENTHETICAL_LENGTH_NOTE.test(f.value)) {
+        pushIssue(issues, bySeverity, {
+          slug,
+          title,
+          severity: "high",
+          detail: `${f.name} contains AI char-count note`,
+        });
+      }
+    }
+
+    const content = p.content_en || "";
+
+    if (PLACEHOLDER_MARKERS.test(content)) {
+      const match = content.match(PLACEHOLDER_MARKERS);
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "critical",
+        detail: `Placeholder marker in body: ${match?.[0]}`,
+      });
+    }
+
+    if (MARKDOWN_LEAK.test(content)) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "high",
+        detail: "Markdown code fences leaked into rendered HTML",
+      });
+    }
+
+    const lower = content.toLowerCase();
+    let genericCount = 0;
+    for (const phrase of AI_GENERIC_PHRASES) {
+      if (lower.includes(phrase)) genericCount++;
+    }
+    if (genericCount >= 3) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "medium",
+        detail: `${genericCount} generic AI phrases (Jan 2026 Authenticity Update demotes)`,
+      });
+    } else if (genericCount > 0) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "low",
+        detail: `${genericCount} generic AI phrase(s) — borderline acceptable`,
+      });
+    }
+  }
+
+  return {
+    name: "unedited",
+    score: scoreFromIssues(bySeverity),
+    issuesCount: issues.length,
+    bySeverity,
+    top: topIssues(issues),
+    nextAction:
+      bySeverity.critical > 0
+        ? "Run content-auto-fix cron — strips known placeholder markers (Section 14 in route). Critical title-prefix leaks need a manual edit on each article."
+        : bySeverity.high > 0
+          ? "Run seo-deep-review cron — rewrites meta with stronger anchors and trims AI residue"
+          : "Content looks edited",
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Dimension 3: News refresh (date-stale content losing relevance)
+// ───────────────────────────────────────────────────────────────────────────
+
+// Recognise a category as "news" by id or by slug-style hint. Different sites
+// use different category schemes so we look at both.
+function isNewsCategoryId(catId: string | null): boolean {
+  if (!catId) return false;
+  return /news|breaking|current|today|update/i.test(catId);
+}
+
+const STALE_TEMPORAL_ANCHORS = [
+  /\btoday\b/i,
+  /\byesterday\b/i,
+  /\bthis\s+week\b/i,
+  /\blast\s+week\b/i,
+  /\bthis\s+month\b/i,
+];
+
+function auditNewsRefresh(posts: ArticleRow[]): DimensionResult {
+  const issues: Issue[] = [];
+  const bySeverity: Record<Severity, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+  };
+
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const sevenDaysMs = 7 * 86400000;
+  const ninetyDaysMs = 90 * 86400000;
+
+  for (const p of posts) {
+    const slug = p.slug;
+    const title = (p.title_en || "").slice(0, 80);
+    const ageMs = now.getTime() - p.created_at.getTime();
+    const isNews = isNewsCategoryId(p.category_id) || /\bnews\b/i.test(slug);
+
+    // News articles older than 7 days are probably stale. Flag for review or
+    // archival — they shouldn't dominate the news rail any more.
+    if (isNews && ageMs > sevenDaysMs && ageMs < ninetyDaysMs) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "high",
+        detail: `News article ${Math.floor(ageMs / 86400000)}d old — past relevance window`,
+      });
+    } else if (isNews && ageMs >= ninetyDaysMs) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "critical",
+        detail: `News article ${Math.floor(ageMs / 86400000)}d old — should be archived or rewritten as evergreen`,
+      });
+    }
+
+    // Stale year reference in any visible field.
+    const allText = [
+      p.title_en,
+      p.title_ar,
+      p.meta_title_en,
+      p.meta_description_en,
+      p.content_en?.slice(0, 4000), // first 4KB is enough for an indicator
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    const yearMatches = [...allText.matchAll(/\b(20\d{2})\b/g)]
+      .map((m) => parseInt(m[1], 10))
+      .filter((y) => y >= 2018 && y < currentYear);
+
+    if (yearMatches.length > 0) {
+      const oldest = Math.min(...yearMatches);
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: oldest <= currentYear - 2 ? "high" : "medium",
+        detail: `Stale year ref: ${[...new Set(yearMatches)].sort().join(", ")} (current: ${currentYear})`,
+      });
+    }
+
+    // Floating temporal anchors only matter on news where "today" actually
+    // refers to a moment in time. On evergreen posts they're less critical.
+    if (isNews) {
+      const content = p.content_en || "";
+      let anchorHits = 0;
+      for (const re of STALE_TEMPORAL_ANCHORS) {
+        if (re.test(content)) anchorHits++;
+      }
+      if (anchorHits >= 2 && ageMs > sevenDaysMs) {
+        pushIssue(issues, bySeverity, {
+          slug,
+          title,
+          severity: "medium",
+          detail: `${anchorHits} floating temporal anchors ("today", "this week") in stale news — meaning has drifted`,
+        });
+      }
+    }
+  }
+
+  return {
+    name: "newsRefresh",
+    score: scoreFromIssues(bySeverity),
+    issuesCount: issues.length,
+    bySeverity,
+    top: topIssues(issues),
+    nextAction:
+      bySeverity.critical > 0
+        ? "Archive stale news articles — set published=false or noindex. Run content-auto-fix Section 12 (thin/stale unpublish)."
+        : bySeverity.high > 0
+          ? "Run dates_audit MCP tool to confirm scope, then bulk-rewrite year references to current year"
+          : "News content is fresh",
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
 // Handler
 // ───────────────────────────────────────────────────────────────────────────
 
@@ -226,8 +473,8 @@ export async function GET(request: NextRequest) {
 
     const dimensions: Record<string, DimensionResult> = {
       photos: auditPhotos(posts),
-      unedited: emptyDimension("unedited", "Pending — Batch 2"),
-      newsRefresh: emptyDimension("newsRefresh", "Pending — Batch 2"),
+      unedited: auditUnedited(posts),
+      newsRefresh: auditNewsRefresh(posts),
       seoUpdates: emptyDimension("seoUpdates", "Pending — Batch 3"),
       aioAlignment: emptyDimension("aioAlignment", "Pending — Batch 3"),
       affiliatePractices: emptyDimension("affiliatePractices", "Pending — Batch 4"),

--- a/yalla_london/app/app/api/admin/public-audit/route.ts
+++ b/yalla_london/app/app/api/admin/public-audit/route.ts
@@ -62,6 +62,7 @@ interface ArticleRow {
   content_ar: string | null;
   featured_image: string | null;
   category_id: string | null;
+  canonical_slug: string | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -436,6 +437,284 @@ function auditNewsRefresh(posts: ArticleRow[]): DimensionResult {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
+// Dimension 4: SEO updates (technical SEO + the Tier 1+2 blind spots)
+// ───────────────────────────────────────────────────────────────────────────
+
+// Length thresholds aligned with lib/seo/standards.ts CONTENT_QUALITY.
+const META_TITLE_MIN = 30;
+const META_TITLE_MAX = 60;
+const META_DESC_MIN = 120;
+const META_DESC_MAX = 160;
+
+// Soft 404 indicators — page returns 200 but content reads like an error.
+const SOFT_404_PATTERNS = [
+  /\bnot\s+found\b/i,
+  /\bcoming\s+soon\b/i,
+  /\bunder\s+construction\b/i,
+  /\bno\s+results?\b/i,
+  /\bsorry,?\s+nothing\b/i,
+  /\b404\b/,
+  /\bpage\s+not\s+available\b/i,
+];
+
+// Schema @type values that must match URL pattern. If the URL doesn't fit, the
+// schema is wrong and Google will reject the rich result.
+const SCHEMA_URL_RULES: Array<{ pattern: RegExp; allowedTypes: string[] }> = [
+  { pattern: /\/blog\//, allowedTypes: ["Article", "BlogPosting", "NewsArticle"] },
+  { pattern: /\/news\//, allowedTypes: ["NewsArticle", "Article"] },
+  { pattern: /\/yachts\//, allowedTypes: ["Product", "Service"] },
+  { pattern: /\/destinations\//, allowedTypes: ["Place", "TouristDestination"] },
+  { pattern: /\/itineraries\//, allowedTypes: ["Trip", "Article"] },
+];
+
+interface SeoSitewide {
+  // Hash → array of slugs that share the same meta_description. Anything with
+  // length > 1 is a duplicate cluster.
+  duplicateMetaDescriptions: Map<string, string[]>;
+  // Slugs whose canonical_slug points to another article that ALSO has a
+  // canonical_slug — that's a 301 chain.
+  redirectChains: Array<{ slug: string; via: string; finalTarget: string }>;
+  // Slugs whose Arabic content is mostly English (server-side language
+  // mismatch — KG-032 risk).
+  arabicLanguageMismatch: string[];
+  // Sitewide signals that aren't per-article.
+  organizationSchemaHasSameAs: boolean | null;
+}
+
+function buildSitewideContext(posts: ArticleRow[]): SeoSitewide {
+  const metaHash = new Map<string, string[]>();
+  for (const p of posts) {
+    const meta = (p.meta_description_en || "").trim();
+    if (meta.length < 50) continue; // ignore empties + obvious stubs
+    const key = meta.toLowerCase().replace(/\s+/g, " ");
+    const existing = metaHash.get(key) || [];
+    existing.push(p.slug);
+    metaHash.set(key, existing);
+  }
+
+  // Build the canonical_slug graph and find chains. A → B → C means article A
+  // 301-redirects to B, but B itself 301-redirects to C. Each hop loses ~5%
+  // authority so we want every redirect to land on the final target directly.
+  const slugToCanonical = new Map<string, string>();
+  for (const p of posts) {
+    if (p.canonical_slug && p.canonical_slug !== p.slug) {
+      slugToCanonical.set(p.slug, p.canonical_slug);
+    }
+  }
+  const chains: SeoSitewide["redirectChains"] = [];
+  for (const [from, via] of slugToCanonical) {
+    const next = slugToCanonical.get(via);
+    if (next && next !== via) {
+      chains.push({ slug: from, via, finalTarget: next });
+    }
+  }
+
+  // Heuristic Arabic-language check: count Arabic Unicode characters in
+  // content_ar. If the field exists but has < 30% Arabic characters in the
+  // first 2000 chars, the article is probably English masquerading as Arabic.
+  const arabicMismatch: string[] = [];
+  for (const p of posts) {
+    const ar = (p.content_ar || "").slice(0, 2000);
+    if (ar.length < 200) continue;
+    const arabicChars = (ar.match(/[؀-ۿ]/g) || []).length;
+    if (arabicChars / ar.length < 0.3) arabicMismatch.push(p.slug);
+  }
+
+  return {
+    duplicateMetaDescriptions: metaHash,
+    redirectChains: chains,
+    arabicLanguageMismatch: arabicMismatch,
+    organizationSchemaHasSameAs: null, // populated lazily by per-article scan
+  };
+}
+
+function auditSeoUpdates(posts: ArticleRow[], sitewide: SeoSitewide): DimensionResult {
+  const issues: Issue[] = [];
+  const bySeverity: Record<Severity, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+  };
+
+  // Resolve duplicate meta_description clusters into per-article issues.
+  for (const [, slugs] of sitewide.duplicateMetaDescriptions) {
+    if (slugs.length < 2) continue;
+    for (const slug of slugs) {
+      const post = posts.find((p) => p.slug === slug);
+      if (!post) continue;
+      pushIssue(issues, bySeverity, {
+        slug,
+        title: (post.title_en || "").slice(0, 80),
+        severity: "high",
+        detail: `Duplicate meta_description shared with ${slugs.length - 1} other article(s) — Google dedupes in SERP`,
+      });
+    }
+  }
+
+  // Redirect chains.
+  for (const c of sitewide.redirectChains) {
+    const post = posts.find((p) => p.slug === c.slug);
+    pushIssue(issues, bySeverity, {
+      slug: c.slug,
+      title: (post?.title_en || "").slice(0, 80),
+      severity: "high",
+      detail: `301 chain: ${c.slug} → ${c.via} → ${c.finalTarget}. Each hop loses ~5% authority.`,
+    });
+  }
+
+  // Arabic language mismatch (KG-032 manifesting as content not just SSR).
+  for (const slug of sitewide.arabicLanguageMismatch) {
+    const post = posts.find((p) => p.slug === slug);
+    pushIssue(issues, bySeverity, {
+      slug,
+      title: (post?.title_en || "").slice(0, 80),
+      severity: "high",
+      detail: "content_ar field exists but is mostly English — hreflang pair is invalidated",
+    });
+  }
+
+  // Per-article checks.
+  for (const p of posts) {
+    const slug = p.slug;
+    const title = (p.title_en || "").slice(0, 80);
+    const content = p.content_en || "";
+
+    // Meta title length.
+    const mt = (p.meta_title_en || "").trim();
+    if (!mt) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "high",
+        detail: "Missing meta_title_en",
+      });
+    } else if (mt.length < META_TITLE_MIN) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "medium",
+        detail: `meta_title_en too short (${mt.length} chars, min ${META_TITLE_MIN})`,
+      });
+    } else if (mt.length > META_TITLE_MAX) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "medium",
+        detail: `meta_title_en too long (${mt.length} chars, max ${META_TITLE_MAX} — gets truncated in SERP)`,
+      });
+    }
+
+    // Meta description length.
+    const md = (p.meta_description_en || "").trim();
+    if (!md) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "high",
+        detail: "Missing meta_description_en",
+      });
+    } else if (md.length < META_DESC_MIN) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "medium",
+        detail: `meta_description_en too short (${md.length} chars, min ${META_DESC_MIN})`,
+      });
+    } else if (md.length > META_DESC_MAX) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "low",
+        detail: `meta_description_en too long (${md.length} chars, soft cap ${META_DESC_MAX})`,
+      });
+    }
+
+    // H1 count — page template provides H1, body must use H2+.
+    const h1Matches = [...content.matchAll(/<h1\b[^>]*>/gi)];
+    if (h1Matches.length > 0) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "high",
+        detail: `Body contains ${h1Matches.length} <h1> tag(s) — page template already provides one`,
+      });
+    }
+
+    // Structured data presence.
+    const hasJsonLd = /<script[^>]*type\s*=\s*"application\/ld\+json"/i.test(content);
+    if (!hasJsonLd) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "medium",
+        detail: "No JSON-LD structured data in body — schema injection may have failed",
+      });
+    } else {
+      // Schema-type mismatch: extract @type values and compare to URL rules.
+      const typeMatches = [...content.matchAll(/"@type"\s*:\s*"([^"]+)"/gi)].map((m) => m[1]);
+      for (const rule of SCHEMA_URL_RULES) {
+        if (!rule.pattern.test(`/blog/${p.slug}`)) continue;
+        const wrong = typeMatches.filter((t) => !rule.allowedTypes.includes(t));
+        if (wrong.length > 0 && typeMatches.length > 0) {
+          pushIssue(issues, bySeverity, {
+            slug,
+            title,
+            severity: "medium",
+            detail: `Schema @type "${wrong.join(", ")}" doesn't fit URL pattern (expected: ${rule.allowedTypes.join("|")})`,
+          });
+        }
+      }
+    }
+
+    // Soft 404: thin content with error-like patterns.
+    const wordCount = content.split(/\s+/).filter(Boolean).length;
+    if (wordCount < 200) {
+      const matchedPatterns = SOFT_404_PATTERNS.filter((re) => re.test(content));
+      if (matchedPatterns.length > 0 || wordCount < 50) {
+        pushIssue(issues, bySeverity, {
+          slug,
+          title,
+          severity: "critical",
+          detail: `Soft 404: ${wordCount} words${matchedPatterns.length > 0 ? " + error-like patterns" : ""}`,
+        });
+      }
+    }
+
+    // Stale lastmod proxy: if updated_at is older than created_at + 30d AND
+    // the article has SEO score issues, sitemap probably isn't telling Google
+    // to re-crawl. (Real check needs sitemap cache lookup — that's a Batch 6
+    // enrichment.)
+    const ageDays = (Date.now() - p.created_at.getTime()) / 86400000;
+    const sinceUpdateDays = (Date.now() - p.updated_at.getTime()) / 86400000;
+    if (ageDays > 30 && sinceUpdateDays > 30 && wordCount < 500) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "low",
+        detail: `${Math.floor(sinceUpdateDays)}d since last update on a thin article — sitemap won't trigger re-crawl`,
+      });
+    }
+  }
+
+  return {
+    name: "seoUpdates",
+    score: scoreFromIssues(bySeverity),
+    issuesCount: issues.length,
+    bySeverity,
+    top: topIssues(issues),
+    nextAction:
+      bySeverity.critical > 0
+        ? "Run content-auto-fix Section 12 — unpublishes soft 404s. Then run dates_audit and dedup meta descriptions via seo-deep-review."
+        : bySeverity.high > 0
+          ? "Run seo-deep-review — rewrites thin meta descriptions, fixes redirect chains via canonical_slug normalization. For Arabic mismatches, regenerate content_ar via daily-content-generate."
+          : bySeverity.medium > 0
+            ? "Run seo-agent — handles meta length trimming and schema injection in batch"
+            : "Technical SEO is clean",
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
 // Handler
 // ───────────────────────────────────────────────────────────────────────────
 
@@ -464,6 +743,7 @@ export async function GET(request: NextRequest) {
         content_ar: true,
         featured_image: true,
         category_id: true,
+        canonical_slug: true,
         created_at: true,
         updated_at: true,
       },
@@ -471,12 +751,14 @@ export async function GET(request: NextRequest) {
       take: Math.min(Math.max(sample, 50), 1000),
     })) as ArticleRow[];
 
+    const sitewide = buildSitewideContext(posts);
+
     const dimensions: Record<string, DimensionResult> = {
       photos: auditPhotos(posts),
       unedited: auditUnedited(posts),
       newsRefresh: auditNewsRefresh(posts),
-      seoUpdates: emptyDimension("seoUpdates", "Pending — Batch 3"),
-      aioAlignment: emptyDimension("aioAlignment", "Pending — Batch 3"),
+      seoUpdates: auditSeoUpdates(posts, sitewide),
+      aioAlignment: emptyDimension("aioAlignment", "Pending — Batch 3b"),
       affiliatePractices: emptyDimension("affiliatePractices", "Pending — Batch 4"),
     };
 

--- a/yalla_london/app/app/api/admin/public-audit/route.ts
+++ b/yalla_london/app/app/api/admin/public-audit/route.ts
@@ -715,6 +715,196 @@ function auditSeoUpdates(posts: ArticleRow[], sitewide: SeoSitewide): DimensionR
 }
 
 // ───────────────────────────────────────────────────────────────────────────
+// Dimension 5: AIO alignment (citability for AI Overviews + ChatGPT/Perplexity)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// AI Overviews now show in 30-60% of US searches. Organic CTR drops 61% on
+// queries that show one. Articles that fit AIO citation patterns recover that
+// loss by getting cited inside the AI answer.
+//
+// Citation-friendly patterns (from Princeton GEO research + standards.ts):
+//   - Direct answer in the first 80 words
+//   - Question-format H2 headings (matches conversational queries)
+//   - Statistics with specific numbers (+37% citation lift)
+//   - Source attributions (+30% citation lift)
+//   - Self-contained paragraphs of 40-200 words
+
+// Strip markup and collapse whitespace so we can measure real reader-facing
+// length, not character count of HTML.
+function stripHtml(s: string): string {
+  return s
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// First N words of plain-text content (used to grade the answer-first opener).
+function firstWords(plain: string, n: number): string {
+  const words = plain.split(/\s+/).filter(Boolean).slice(0, n);
+  return words.join(" ");
+}
+
+// Heuristic for "looks like a direct answer": the opening contains a complete
+// declarative sentence with a noun + verb pattern, AND it isn't a generic AI
+// preamble. Imperfect but practical — the alternative (LLM grading) is too
+// expensive at scale.
+function looksLikeDirectAnswer(opener: string): boolean {
+  if (opener.length < 40) return false;
+  // Reject openers that start with a generic preamble pattern.
+  const preambles = [
+    /^welcome\b/i,
+    /^are you\b/i,
+    /^have you ever\b/i,
+    /^if you('|')?re\b/i,
+    /^whether you('|')?re\b/i,
+    /^when it comes to\b/i,
+    /^in this (article|post|guide|comprehensive)\b/i,
+    /^let('|')?s (dive|explore|talk)\b/i,
+    /^picture this\b/i,
+    /^imagine\b/i,
+  ];
+  for (const re of preambles) if (re.test(opener.trim())) return false;
+  // Look for a basic subject-verb structure in the first sentence.
+  const firstSentence = opener.split(/[.!?]/)[0] || "";
+  return /\b(is|are|was|were|has|have|costs?|takes?|offers?|provides?|sits?|lies?|opens?|closes?|requires?)\b/i.test(
+    firstSentence,
+  );
+}
+
+const QUESTION_H2_PATTERNS = [
+  /^how\s+/i,
+  /^what\s+/i,
+  /^why\s+/i,
+  /^when\s+/i,
+  /^where\s+/i,
+  /^who\s+/i,
+  /^which\s+/i,
+  /^is\s+/i,
+  /^are\s+/i,
+  /^can\s+/i,
+  /^should\s+/i,
+  /^do\s+/i,
+  /^does\s+/i,
+];
+
+function auditAioAlignment(posts: ArticleRow[]): DimensionResult {
+  const issues: Issue[] = [];
+  const bySeverity: Record<Severity, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+  };
+
+  for (const p of posts) {
+    const slug = p.slug;
+    const title = (p.title_en || "").slice(0, 80);
+    const content = p.content_en || "";
+    const plain = stripHtml(content);
+
+    if (plain.length < 200) continue; // soft-404 territory — handled by SEO dim
+
+    // Check 1: answer-first opener.
+    const opener = firstWords(plain, 80);
+    if (!looksLikeDirectAnswer(opener)) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "high",
+        detail: `First 80 words don't read as a direct answer (starts: "${opener.slice(0, 60)}...")`,
+      });
+    }
+
+    // Check 2: question-format H2 count.
+    const h2Texts = [...content.matchAll(/<h2\b[^>]*>([\s\S]*?)<\/h2>/gi)].map((m) => stripHtml(m[1]));
+    const questionH2s = h2Texts.filter((t) => QUESTION_H2_PATTERNS.some((re) => re.test(t.trim())));
+    if (h2Texts.length >= 3 && questionH2s.length < 2) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "medium",
+        detail: `Only ${questionH2s.length}/${h2Texts.length} H2s are question-format — AI Overviews favor Q&A structure`,
+      });
+    }
+
+    // Check 3: statistics density. Real numbers beat vague adjectives in
+    // citation context. Per Princeton GEO study: stats lift visibility +37%.
+    const statMatches = [
+      ...plain.matchAll(/\b\d+(?:[.,]\d+)?\s*(?:%|percent|million|billion|users?|visitors?|reviews?|stars?)\b/gi),
+      ...plain.matchAll(/[£$€]\s*\d/g),
+      ...plain.matchAll(/\b\d{4}\s*(?:guests?|seats?|rooms?|members?)\b/gi),
+    ];
+    if (statMatches.length < 2 && plain.length > 800) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "medium",
+        detail: `Only ${statMatches.length} concrete stat(s) in ${Math.floor(plain.length / 5)} word article — add 2+ for AIO citability`,
+      });
+    }
+
+    // Check 4: source attributions. Phrases that signal "we're citing" make
+    // the article more likely to be cited in turn (+30% per Princeton).
+    const attributionPatterns = [
+      /\baccording to\b/i,
+      /\bdata from\b/i,
+      /\bresearch by\b/i,
+      /\bas reported by\b/i,
+      /\bsource:\s*[A-Z]/i,
+      /\bcited by\b/i,
+      /\b(transport for london|tfl|bbc|reuters|associated press|gov\.uk|government|office for national statistics|ons)\b/i,
+    ];
+    let attributions = 0;
+    for (const re of attributionPatterns) if (re.test(plain)) attributions++;
+    if (attributions === 0 && plain.length > 1000) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "low",
+        detail: "No source attributions — citing authoritative sources lifts AIO visibility +30%",
+      });
+    }
+
+    // Check 5: self-contained paragraph structure. Walls of text don't get
+    // cited. Sweet spot: 40-200 words per paragraph.
+    const paragraphs = content
+      .split(/<\/?p[^>]*>/gi)
+      .map((p) => stripHtml(p))
+      .filter((p) => p.length > 30);
+    const wellSized = paragraphs.filter((p) => {
+      const w = p.split(/\s+/).filter(Boolean).length;
+      return w >= 40 && w <= 200;
+    });
+    if (paragraphs.length >= 5 && wellSized.length / paragraphs.length < 0.3) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "low",
+        detail: `Only ${wellSized.length}/${paragraphs.length} paragraphs in citation-friendly 40-200 word range`,
+      });
+    }
+  }
+
+  return {
+    name: "aioAlignment",
+    score: scoreFromIssues(bySeverity),
+    issuesCount: issues.length,
+    bySeverity,
+    top: topIssues(issues),
+    nextAction:
+      bySeverity.high > 0
+        ? "Run seo-deep-review — rewrites article openers to lead with the direct answer (Princeton GEO pattern)"
+        : bySeverity.medium > 0
+          ? "Refresh content via daily-content-generate with explicit question-H2 + stats prompts"
+          : "AIO alignment is healthy",
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
 // Handler
 // ───────────────────────────────────────────────────────────────────────────
 
@@ -758,7 +948,7 @@ export async function GET(request: NextRequest) {
       unedited: auditUnedited(posts),
       newsRefresh: auditNewsRefresh(posts),
       seoUpdates: auditSeoUpdates(posts, sitewide),
-      aioAlignment: emptyDimension("aioAlignment", "Pending — Batch 3b"),
+      aioAlignment: auditAioAlignment(posts),
       affiliatePractices: emptyDimension("affiliatePractices", "Pending — Batch 4"),
     };
 

--- a/yalla_london/app/app/api/admin/public-audit/route.ts
+++ b/yalla_london/app/app/api/admin/public-audit/route.ts
@@ -1,0 +1,256 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+/**
+ * Public Website Audit
+ *
+ * One endpoint, six dimensions. Scans every published article ONCE and
+ * accumulates findings per dimension so we can act on them as a single
+ * package instead of running six separate audits.
+ *
+ *   1. Photos              — missing featured / no alt / suspicious stock host
+ *   2. Unedited content    — AI artifacts that leaked into published copy
+ *   3. News refresh        — date-stale news + obsolete temporal anchors
+ *   4. SEO updates         — meta length, H1 count, structured data, canonical
+ *   5. AIO alignment       — answer-first, question H2s, stats / citations
+ *   6. Affiliate practices — rel attributes, disclosure, anchor variety
+ *
+ * Each dimension returns: score (0-100), issuesCount, top examples with slug
+ * + specific issue text + actionable next step (which existing cron auto-fixes
+ * it OR what manual action is needed).
+ *
+ * Builds incrementally — Batch 1 ships the skeleton + dimension #1 (Photos)
+ * so partial responses are useful even if a session times out.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/admin-middleware";
+import { getDefaultSiteId } from "@/config/sites";
+import { prisma } from "@/lib/db";
+
+const BUDGET_MS = 100_000;
+
+type Severity = "critical" | "high" | "medium" | "low";
+
+interface Issue {
+  slug: string;
+  title: string;
+  severity: Severity;
+  detail: string;
+}
+
+interface DimensionResult {
+  name: string;
+  score: number;
+  issuesCount: number;
+  bySeverity: Record<Severity, number>;
+  top: Issue[];
+  nextAction: string;
+}
+
+interface ArticleRow {
+  id: string;
+  slug: string;
+  siteId: string;
+  title_en: string | null;
+  title_ar: string | null;
+  meta_title_en: string | null;
+  meta_title_ar: string | null;
+  meta_description_en: string | null;
+  meta_description_ar: string | null;
+  content_en: string | null;
+  content_ar: string | null;
+  featured_image: string | null;
+  category_id: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+function emptyDimension(name: string, nextAction: string): DimensionResult {
+  return {
+    name,
+    score: 100,
+    issuesCount: 0,
+    bySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+    top: [],
+    nextAction,
+  };
+}
+
+function scoreFromIssues(bySeverity: Record<Severity, number>): number {
+  // Caps each severity bucket so a single ruined article can't tank the
+  // whole dimension. Floors the result at 0.
+  const penalty =
+    Math.min(bySeverity.critical, 20) * 5 +
+    Math.min(bySeverity.high, 30) * 2 +
+    Math.min(bySeverity.medium, 50) * 1 +
+    Math.min(bySeverity.low, 80) * 0.25;
+  return Math.max(0, Math.round(100 - penalty));
+}
+
+function pushIssue(issues: Issue[], bySeverity: Record<Severity, number>, issue: Issue): void {
+  issues.push(issue);
+  bySeverity[issue.severity]++;
+}
+
+function topIssues(issues: Issue[], limit = 10): Issue[] {
+  const order: Record<Severity, number> = {
+    critical: 0,
+    high: 1,
+    medium: 2,
+    low: 3,
+  };
+  return [...issues].sort((a, b) => order[a.severity] - order[b.severity]).slice(0, limit);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Dimension 1: Photos
+// ───────────────────────────────────────────────────────────────────────────
+
+const SUSPICIOUS_STOCK_PATTERN =
+  /(istockphoto|shutterstock|gettyimages|adobestock|123rf|dreamstime|stock\.adobe|pixabay|pexels)/i;
+
+function auditPhotos(posts: ArticleRow[]): DimensionResult {
+  const issues: Issue[] = [];
+  const bySeverity: Record<Severity, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+  };
+
+  for (const p of posts) {
+    const slug = p.slug;
+    const title = (p.title_en || "").slice(0, 80);
+
+    if (!p.featured_image || p.featured_image.trim() === "") {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "critical",
+        detail: "Missing featured_image",
+      });
+    }
+
+    const content = p.content_en || "";
+    const imgs = [...content.matchAll(/<img\b[^>]*>/gi)].map((m) => m[0]);
+
+    if (imgs.length === 0 && (p.featured_image || "").trim() !== "") {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "high",
+        detail: "Body has no <img> tags (only the featured image)",
+      });
+    }
+
+    const missingAlt = imgs.filter((tag) => !/\balt\s*=\s*"[^"]*\S[^"]*"/i.test(tag));
+    if (missingAlt.length > 0) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "medium",
+        detail: `${missingAlt.length} <img> tag(s) missing or empty alt`,
+      });
+    }
+
+    const stockHosts = new Set<string>();
+    for (const tag of imgs) {
+      const src = /\bsrc\s*=\s*"([^"]+)"/i.exec(tag);
+      if (!src) continue;
+      try {
+        const u = new URL(src[1]);
+        if (SUSPICIOUS_STOCK_PATTERN.test(u.hostname)) stockHosts.add(u.hostname);
+      } catch {
+        /* relative URL — ignore */
+      }
+    }
+    if (stockHosts.size > 0) {
+      pushIssue(issues, bySeverity, {
+        slug,
+        title,
+        severity: "medium",
+        detail: `Stock photo host(s): ${[...stockHosts].join(", ")}`,
+      });
+    }
+  }
+
+  return {
+    name: "photos",
+    score: scoreFromIssues(bySeverity),
+    issuesCount: issues.length,
+    bySeverity,
+    top: topIssues(issues),
+    nextAction:
+      bySeverity.critical > 0 || bySeverity.high > 0
+        ? "Run image_fix MCP tool (triggers image-pipeline cron) — fills missing featured images and replaces blocked stock photos"
+        : "Photos look good",
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Handler
+// ───────────────────────────────────────────────────────────────────────────
+
+export async function GET(request: NextRequest) {
+  const start = Date.now();
+  const authError = await requireAdmin(request);
+  if (authError) return authError;
+
+  const siteId = request.nextUrl.searchParams.get("siteId") || getDefaultSiteId();
+  const sample = parseInt(request.nextUrl.searchParams.get("sample") || "500", 10);
+
+  try {
+    const posts = (await prisma.blogPost.findMany({
+      where: { siteId, published: true },
+      select: {
+        id: true,
+        slug: true,
+        siteId: true,
+        title_en: true,
+        title_ar: true,
+        meta_title_en: true,
+        meta_title_ar: true,
+        meta_description_en: true,
+        meta_description_ar: true,
+        content_en: true,
+        content_ar: true,
+        featured_image: true,
+        category_id: true,
+        created_at: true,
+        updated_at: true,
+      },
+      orderBy: { created_at: "desc" },
+      take: Math.min(Math.max(sample, 50), 1000),
+    })) as ArticleRow[];
+
+    const dimensions: Record<string, DimensionResult> = {
+      photos: auditPhotos(posts),
+      unedited: emptyDimension("unedited", "Pending — Batch 2"),
+      newsRefresh: emptyDimension("newsRefresh", "Pending — Batch 2"),
+      seoUpdates: emptyDimension("seoUpdates", "Pending — Batch 3"),
+      aioAlignment: emptyDimension("aioAlignment", "Pending — Batch 3"),
+      affiliatePractices: emptyDimension("affiliatePractices", "Pending — Batch 4"),
+    };
+
+    return NextResponse.json({
+      success: true,
+      site: siteId,
+      generatedAt: new Date().toISOString(),
+      durationMs: Date.now() - start,
+      totalArticlesScanned: posts.length,
+      dimensions,
+      _format: "yalla-public-audit-v1",
+      _note:
+        "Batch 1 of 5 — only the photos dimension is implemented. The other 5 dimensions return empty placeholders so the response shape stays stable.",
+    });
+  } catch (err: unknown) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/yalla_london/app/app/api/cron/audit-roundup/route.ts
+++ b/yalla_london/app/app/api/cron/audit-roundup/route.ts
@@ -1,0 +1,305 @@
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+/**
+ * Audit Roundup Cron — Runs twice daily (07:00 + 19:00 UTC per vercel.json)
+ *
+ * Pulls the audit-roundup aggregator → filters to top auto-fixable actions →
+ * executes them within budget → logs each fix to AutoFixLog with before/after
+ * snapshots so Batch 8's enrichment layer can compute real ROI 7d later.
+ *
+ * Budget: 280s (300s maxDuration − 20s buffer).
+ * Per-fix budget: 30s (caps a single slow cron from eating the whole window).
+ * Max fixes per run: 10 (so one run can't shred half the site if scoring goes
+ * sideways).
+ *
+ * Auth: CRON_SECRET (scheduled) OR admin session (manual dashboard trigger).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { logCronExecution } from "@/lib/cron-logger";
+import { runAuditRoundup } from "@/app/api/admin/audit-roundup/route";
+import { getActiveSiteIds } from "@/config/sites";
+import { prisma } from "@/lib/db";
+
+const TOTAL_BUDGET_MS = 280_000;
+const PER_FIX_BUDGET_MS = 30_000;
+const MAX_FIXES_PER_RUN = 10;
+// Minimum ROI score to bother executing — anything lower wastes the cron run.
+const MIN_ROI_SCORE = 50;
+
+interface FixOutcome {
+  site: string;
+  source: string;
+  dimension?: string;
+  severity: string;
+  detail: string;
+  cron?: string;
+  roiScore: number;
+  status: "executed" | "skipped" | "failed" | "escalated";
+  durationMs: number;
+  error?: string;
+  resultSummary?: unknown;
+}
+
+async function callCronInternal(
+  path: string,
+  cronSecret: string,
+): Promise<{ ok: boolean; data?: unknown; error?: string }> {
+  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000";
+  try {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${cronSecret}`,
+        "Content-Type": "application/json",
+      },
+      signal: AbortSignal.timeout(PER_FIX_BUDGET_MS - 1000),
+    });
+    const text = await res.text();
+    let data: unknown;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = text;
+    }
+    return { ok: res.ok, data };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function logFixToAutoFixLog(
+  siteId: string,
+  fixType: string,
+  agent: string,
+  before: unknown,
+  after: unknown,
+  success: boolean,
+  errorMsg?: string,
+) {
+  try {
+    await prisma.autoFixLog.create({
+      data: {
+        siteId,
+        targetType: "audit-roundup",
+        targetId: `roundup-${Date.now()}`,
+        fixType,
+        agent,
+        before: (before as Record<string, unknown>) ?? null,
+        after: (after as Record<string, unknown>) ?? null,
+        success,
+        error: errorMsg,
+      },
+    });
+  } catch (err: unknown) {
+    console.warn("[audit-roundup] AutoFixLog write failed:", err instanceof Error ? err.message : String(err));
+  }
+}
+
+async function processSite(siteId: string, cronSecret: string, remainingBudgetMs: number): Promise<FixOutcome[]> {
+  const siteStart = Date.now();
+  const outcomes: FixOutcome[] = [];
+
+  let report;
+  try {
+    report = await runAuditRoundup(siteId);
+  } catch (err: unknown) {
+    outcomes.push({
+      site: siteId,
+      source: "roundup-error",
+      severity: "high",
+      detail: "runAuditRoundup() failed",
+      roiScore: 0,
+      status: "failed",
+      durationMs: Date.now() - siteStart,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return outcomes;
+  }
+
+  const fixable = report.topActions
+    .filter((a) => a.fixability === "auto" && a.cron && a.roiScore >= MIN_ROI_SCORE)
+    .slice(0, MAX_FIXES_PER_RUN);
+
+  // De-dup so we don't fire the same cron twice in one run (multiple findings
+  // can route to the same auto-fix).
+  const seen = new Set<string>();
+  const queue = fixable.filter((f) => {
+    if (!f.cron) return false;
+    if (seen.has(f.cron)) return false;
+    seen.add(f.cron);
+    return true;
+  });
+
+  for (const action of queue) {
+    const elapsed = Date.now() - siteStart;
+    if (elapsed > remainingBudgetMs - PER_FIX_BUDGET_MS) {
+      outcomes.push({
+        site: siteId,
+        source: action.source,
+        dimension: action.dimension,
+        severity: action.severity,
+        detail: action.detail,
+        cron: action.cron,
+        roiScore: action.roiScore,
+        status: "skipped",
+        durationMs: 0,
+        error: "site budget exhausted",
+      });
+      continue;
+    }
+
+    const fixStart = Date.now();
+    const result = await callCronInternal(action.cron!, cronSecret);
+    const fixDuration = Date.now() - fixStart;
+    const success = result.ok;
+
+    outcomes.push({
+      site: siteId,
+      source: action.source,
+      dimension: action.dimension,
+      severity: action.severity,
+      detail: action.detail,
+      cron: action.cron,
+      roiScore: action.roiScore,
+      status: success ? "executed" : "failed",
+      durationMs: fixDuration,
+      error: success ? undefined : result.error,
+      resultSummary: result.data,
+    });
+
+    // before-snapshot is the finding itself; after-snapshot is the cron's
+    // immediate response. Real ROI computation (GSC delta 7d later) lives in
+    // the Batch 8 enrichment layer.
+    await logFixToAutoFixLog(
+      siteId,
+      `roundup:${action.dimension || action.source}`,
+      "audit-roundup",
+      {
+        severity: action.severity,
+        detail: action.detail,
+        affectedSlug: action.affectedSlug,
+        roiScore: action.roiScore,
+        cron: action.cron,
+        capturedAt: new Date().toISOString(),
+      },
+      {
+        cronResponse: result.data,
+        cronOk: result.ok,
+        durationMs: fixDuration,
+      },
+      success,
+      success ? undefined : result.error,
+    );
+  }
+
+  return outcomes;
+}
+
+async function handleAuditRoundup(request: NextRequest) {
+  const cronStart = Date.now();
+
+  // Auth: CRON_SECRET (scheduled) OR admin session (manual).
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+  const hasCronAuth = !cronSecret || authHeader === `Bearer ${cronSecret}`;
+  if (!hasCronAuth) {
+    const { requireAdmin } = await import("@/lib/admin-middleware");
+    const authError = await requireAdmin(request);
+    if (authError) return authError;
+  }
+
+  // Feature flag guard.
+  const { checkCronEnabled } = await import("@/lib/cron-feature-guard");
+  const flagResponse = await checkCronEnabled("audit-roundup");
+  if (flagResponse) return flagResponse;
+
+  // Healthcheck mode.
+  if (request.nextUrl.searchParams.get("healthcheck") === "true") {
+    return NextResponse.json({
+      status: "healthy",
+      endpoint: "audit-roundup",
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  const sites = getActiveSiteIds();
+  const allOutcomes: FixOutcome[] = [];
+  let executedCount = 0;
+  let failedCount = 0;
+  let escalatedCount = 0;
+
+  try {
+    for (const siteId of sites) {
+      const elapsed = Date.now() - cronStart;
+      const remaining = TOTAL_BUDGET_MS - elapsed;
+      if (remaining < 60_000) {
+        // Less than 60s left — don't even start another site.
+        break;
+      }
+      const perSiteBudget = Math.floor(remaining / Math.max(1, sites.length));
+      const outcomes = await processSite(siteId, cronSecret || "dev", Math.max(perSiteBudget, 60_000));
+      allOutcomes.push(...outcomes);
+      executedCount += outcomes.filter((o) => o.status === "executed").length;
+      failedCount += outcomes.filter((o) => o.status === "failed").length;
+      escalatedCount += outcomes.filter((o) => o.status === "escalated").length;
+    }
+  } catch (err: unknown) {
+    const totalDuration = Date.now() - cronStart;
+    await logCronExecution({
+      jobName: "audit-roundup",
+      jobType: "maintenance",
+      status: "failed",
+      durationMs: totalDuration,
+      itemsProcessed: allOutcomes.length,
+      resultSummary: { error: err instanceof Error ? err.message : String(err), partial: allOutcomes },
+      errorMessage: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      { success: false, error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+
+  const totalDuration = Date.now() - cronStart;
+  const overallSuccess = failedCount === 0;
+
+  await logCronExecution({
+    jobName: "audit-roundup",
+    jobType: "maintenance",
+    status: overallSuccess ? "completed" : "failed",
+    durationMs: totalDuration,
+    itemsProcessed: allOutcomes.length,
+    itemsSucceeded: executedCount,
+    itemsFailed: failedCount,
+    resultSummary: {
+      sites: sites.length,
+      executed: executedCount,
+      failed: failedCount,
+      escalated: escalatedCount,
+      durationMs: totalDuration,
+      outcomes: allOutcomes.map((o) => ({
+        site: o.site,
+        source: o.source,
+        dimension: o.dimension,
+        cron: o.cron,
+        status: o.status,
+        roiScore: o.roiScore,
+      })),
+    },
+  });
+
+  return NextResponse.json({
+    success: overallSuccess,
+    sites: sites.length,
+    executed: executedCount,
+    failed: failedCount,
+    escalated: escalatedCount,
+    durationMs: totalDuration,
+    outcomes: allOutcomes,
+  });
+}
+
+export const GET = handleAuditRoundup;
+export const POST = handleAuditRoundup;

--- a/yalla_london/app/app/api/cron/audit-roundup/route.ts
+++ b/yalla_london/app/app/api/cron/audit-roundup/route.ts
@@ -247,10 +247,7 @@ async function handleAuditRoundup(request: NextRequest) {
     }
   } catch (err: unknown) {
     const totalDuration = Date.now() - cronStart;
-    await logCronExecution({
-      jobName: "audit-roundup",
-      jobType: "maintenance",
-      status: "failed",
+    await logCronExecution("audit-roundup", "failed", {
       durationMs: totalDuration,
       itemsProcessed: allOutcomes.length,
       resultSummary: { error: err instanceof Error ? err.message : String(err), partial: allOutcomes },
@@ -265,10 +262,7 @@ async function handleAuditRoundup(request: NextRequest) {
   const totalDuration = Date.now() - cronStart;
   const overallSuccess = failedCount === 0;
 
-  await logCronExecution({
-    jobName: "audit-roundup",
-    jobType: "maintenance",
-    status: overallSuccess ? "completed" : "failed",
+  await logCronExecution("audit-roundup", overallSuccess ? "completed" : "failed", {
     durationMs: totalDuration,
     itemsProcessed: allOutcomes.length,
     itemsSucceeded: executedCount,

--- a/yalla_london/app/lib/cron-feature-guard.ts
+++ b/yalla_london/app/lib/cron-feature-guard.ts
@@ -50,13 +50,14 @@ const CRON_FLAG_MAP: Record<string, string> = {
   "seo-orchestrator": "CRON_SEO_ORCHESTRATOR",
   "seo-deep-review": "CRON_SEO_DEEP_REVIEW",
   "seo-audit-runner": "CRON_SEO_AUDIT_RUNNER",
-  "sweeper": "CRON_SWEEPER",
+  sweeper: "CRON_SWEEPER",
   "diagnostic-sweep": "CRON_DIAGNOSTIC_SWEEP",
+  "audit-roundup": "CRON_AUDIT_ROUNDUP",
   "pipeline-health": "CRON_PIPELINE_HEALTH",
   "scheduled-publish": "CRON_SCHEDULED_PUBLISH",
   "reserve-publisher": "CRON_RESERVE_PUBLISHER",
   "trends-monitor": "CRON_TRENDS_MONITOR",
-  "analytics": "CRON_ANALYTICS",
+  analytics: "CRON_ANALYTICS",
   "gsc-sync": "CRON_GSC_SYNC",
   "affiliate-injection": "CRON_AFFILIATE_INJECTION",
   "google-indexing": "CRON_GOOGLE_INDEXING",
@@ -64,7 +65,7 @@ const CRON_FLAG_MAP: Record<string, string> = {
   "london-news": "CRON_LONDON_NEWS",
   "fact-verification": "CRON_FACT_VERIFICATION",
   "site-health-check": "CRON_SITE_HEALTH_CHECK",
-  "social": "CRON_SOCIAL",
+  social: "CRON_SOCIAL",
   "subscriber-emails": "CRON_SUBSCRIBER_EMAILS",
   "schedule-executor": "CRON_SCHEDULE_EXECUTOR",
   "affiliate-sync-advertisers": "CRON_AFFILIATE_SYNC_ADVERTISERS",
@@ -113,10 +114,7 @@ const CRON_FLAG_MAP: Record<string, string> = {
  *   const disabled = await checkCronEnabled("content-builder");
  *   if (disabled) return { skipped: true };
  */
-export async function checkCronEnabled(
-  jobName: string,
-  siteId?: string
-): Promise<NextResponse | null> {
+export async function checkCronEnabled(jobName: string, siteId?: string): Promise<NextResponse | null> {
   // Resolve aliases first (e.g. "discover-deals" → "affiliate-discover-deals")
   const canonicalName = CRON_NAME_ALIASES[jobName] || jobName;
   const flagKey = CRON_FLAG_MAP[canonicalName] || `CRON_${canonicalName.toUpperCase().replace(/-/g, "_")}`;

--- a/yalla_london/app/scripts/mcp-platform-server.ts
+++ b/yalla_london/app/scripts/mcp-platform-server.ts
@@ -2103,6 +2103,166 @@ server.tool(
   },
 );
 
+// ═══════════════════════════════════════════════════════════════════════════
+// AUDIT AND FIX (cross-MCP enrichment + optional execute)
+// ═══════════════════════════════════════════════════════════════════════════
+
+server.tool(
+  "audit_and_fix",
+  'When Khaled says "audit and fix issues" — the full flow. Runs the audit-roundup aggregator, enriches each finding with last-30d GSC clicks + impressions + CJ revenue per affected article, re-ranks by ENRICHED ROI (real revenue impact, not just severity), and optionally executes the top N auto-fixable actions. Set execute=true to run fixes. Returns: per-finding enrichment, re-ranked top actions, execution outcomes.',
+  {
+    siteId: z.string().optional().describe("Site ID (default: yalla-london)"),
+    execute: z
+      .boolean()
+      .optional()
+      .describe("Set true to actually run the top N auto-fixes (default: false — audit only)"),
+    maxFixes: z.number().optional().describe("Cap on fixes to execute when execute=true (default: 5)"),
+    enrichDays: z.number().optional().describe("GSC + CJ lookback window in days (default: 30)"),
+  },
+  async ({ siteId, execute, maxFixes, enrichDays }) => {
+    try {
+      const site = siteId || getDefaultSiteId();
+      const days = enrichDays || 30;
+      const since = new Date(Date.now() - days * 86400000);
+      const cap = Math.min(maxFixes || 5, 10);
+      const start = Date.now();
+
+      // Step 1: pull aggregator
+      const { runAuditRoundup } = await import("@/app/api/admin/audit-roundup/route");
+      const report = await runAuditRoundup(site);
+
+      // Step 2: collect every affected slug across all actions
+      const affectedSlugs = new Set<string>();
+      for (const a of report.allActions) {
+        if (a.affectedSlug) affectedSlugs.add(a.affectedSlug);
+      }
+      const slugs = [...affectedSlugs];
+
+      // Step 3: enrich with GSC + CJ in parallel
+      const domain = getSiteDomain(site).replace(/\/$/, "");
+      const possibleUrls = slugs.flatMap((s) => [`${domain}/blog/${s}`, `${domain}/blog/${s}/`, `${domain}/${s}`]);
+
+      const [gscRows, cjRows] = await Promise.all([
+        slugs.length > 0
+          ? prisma.gscPagePerformance.findMany({
+              where: {
+                site_id: site,
+                url: { in: possibleUrls },
+                date: { gte: since },
+              },
+              select: { url: true, clicks: true, impressions: true, position: true },
+            })
+          : [],
+        slugs.length > 0
+          ? prisma.cjCommission.findMany({
+              where: {
+                OR: [{ siteId: site }, { siteId: null }],
+                eventDate: { gte: since },
+                sessionId: { not: null },
+              },
+              select: { sessionId: true, commissionAmount: true },
+              take: 5000,
+            })
+          : [],
+      ]);
+
+      // Step 4: build per-slug enrichment map
+      const enrichBySlug = new Map<
+        string,
+        { clicks: number; impressions: number; position: number; revenueUsd: number }
+      >();
+      for (const slug of slugs) {
+        enrichBySlug.set(slug, { clicks: 0, impressions: 0, position: 0, revenueUsd: 0 });
+      }
+      const positionSamples = new Map<string, number[]>();
+      for (const row of gscRows) {
+        // Resolve url back to slug
+        const matched = slugs.find((s) => row.url.includes(`/blog/${s}`) || row.url.endsWith(`/${s}`));
+        if (!matched) continue;
+        const e = enrichBySlug.get(matched)!;
+        e.clicks += row.clicks;
+        e.impressions += row.impressions;
+        const arr = positionSamples.get(matched) || [];
+        arr.push(row.position);
+        positionSamples.set(matched, arr);
+      }
+      for (const [slug, samples] of positionSamples) {
+        if (samples.length === 0) continue;
+        const avg = samples.reduce((s, v) => s + v, 0) / samples.length;
+        enrichBySlug.get(slug)!.position = Math.round(avg * 10) / 10;
+      }
+      // SID format is `{siteId}_{slug}` — match each commission to its slug
+      const sitePrefix = `${site}_`;
+      for (const c of cjRows) {
+        const sid = c.sessionId || "";
+        if (!sid.startsWith(sitePrefix)) continue;
+        const slugFromSid = sid.slice(sitePrefix.length);
+        // SID may include suffixes — find best slug match
+        const matched = slugs.find((s) => slugFromSid === s || slugFromSid.startsWith(s));
+        if (!matched) continue;
+        enrichBySlug.get(matched)!.revenueUsd += Number(c.commissionAmount) || 0;
+      }
+
+      // Step 5: re-rank actions by enriched ROI
+      // Formula: original roiScore × log(1 + clicks) × (1 + revenue/100)
+      // Articles with traffic + revenue jump to the top regardless of severity.
+      const enrichedActions = report.allActions.map((a) => {
+        const e = a.affectedSlug ? enrichBySlug.get(a.affectedSlug) : undefined;
+        const trafficMultiplier = e ? Math.log(1 + e.clicks * 10 + e.impressions / 100) : 1;
+        const revenueMultiplier = e ? 1 + e.revenueUsd / 100 : 1;
+        const enrichedScore = Math.round(a.roiScore * trafficMultiplier * revenueMultiplier);
+        return {
+          ...a,
+          enrichment: e || null,
+          enrichedRoiScore: enrichedScore,
+        };
+      });
+      enrichedActions.sort((a, b) => b.enrichedRoiScore - a.enrichedRoiScore);
+
+      // Step 6: optionally execute top N auto-fixes
+      const executed: Array<{ cron: string; ok: boolean; data?: unknown; error?: string; durationMs: number }> = [];
+      if (execute) {
+        const seen = new Set<string>();
+        const toRun = enrichedActions
+          .filter((a) => a.fixability === "auto" && a.cron && !seen.has(a.cron) && (seen.add(a.cron!), true))
+          .slice(0, cap);
+        for (const action of toRun) {
+          if (!action.cron) continue;
+          const fixStart = Date.now();
+          const result = await callCron(action.cron);
+          executed.push({
+            cron: action.cron,
+            ok: result.ok,
+            data: result.data,
+            error: result.error,
+            durationMs: Date.now() - fixStart,
+          });
+        }
+      }
+
+      return json({
+        site,
+        generatedAt: new Date().toISOString(),
+        durationMs: Date.now() - start,
+        execute: execute || false,
+        windowDays: days,
+        slugsEnriched: slugs.length,
+        topActions: enrichedActions.slice(0, 15),
+        enrichedActionsTotal: enrichedActions.length,
+        executed,
+        plainLanguageSummary: report.plainLanguageSummary,
+        baselineSources: report.sources,
+        baselineTotals: report.totals,
+        nextStep: execute
+          ? `${executed.filter((e) => e.ok).length}/${executed.length} auto-fixes executed. Re-run audit_and_fix in 7 days to measure GSC delta vs the AutoFixLog before-snapshots.`
+          : "Set execute=true to run the top auto-fixes. Manual + semi-auto findings need human review either way.",
+      });
+    } catch (err: unknown) {
+      return error(err instanceof Error ? err.message : String(err));
+    }
+  },
+);
+
 // ---------------------------------------------------------------------------
 // Start server
 // ---------------------------------------------------------------------------

--- a/yalla_london/app/scripts/mcp-platform-server.ts
+++ b/yalla_london/app/scripts/mcp-platform-server.ts
@@ -20,9 +20,7 @@ import { resolve } from "path";
 import { fileURLToPath } from "url";
 
 // Load .env.local from the app directory (4 fallback paths)
-const __script_dir = typeof __dirname !== "undefined"
-  ? __dirname
-  : resolve(fileURLToPath(import.meta.url), "..");
+const __script_dir = typeof __dirname !== "undefined" ? __dirname : resolve(fileURLToPath(import.meta.url), "..");
 config({ path: resolve(__script_dir, "../.env.local") });
 config({ path: resolve(__script_dir, "../.env") });
 config({ path: resolve(process.cwd(), "yalla_london/app/.env.local") });
@@ -46,10 +44,10 @@ function getDefaultSiteId(): string {
 function getSiteDomain(siteId: string): string {
   const domains: Record<string, string> = {
     "yalla-london": "https://www.yalla-london.com",
-    "arabaldives": "https://www.arabaldives.com",
+    arabaldives: "https://www.arabaldives.com",
     "french-riviera": "https://www.yallariviera.com",
-    "istanbul": "https://www.yallaistanbul.com",
-    "thailand": "https://www.yallathailand.com",
+    istanbul: "https://www.yallaistanbul.com",
+    thailand: "https://www.yallathailand.com",
     "zenitha-yachts-med": "https://www.zenithayachts.com",
   };
   return domains[siteId] || domains["yalla-london"]!;
@@ -81,7 +79,11 @@ async function callCron(path: string): Promise<{ ok: boolean; data?: unknown; er
     });
     const text = await res.text();
     let data: unknown;
-    try { data = JSON.parse(text); } catch { data = text; }
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = text;
+    }
     return { ok: res.ok, data };
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -135,13 +137,15 @@ server.tool(
         take: 100,
         select: { job_name: true, status: true, error_message: true, duration_ms: true, started_at: true },
       });
-      const failedCrons = recentCrons.filter(c => c.status === "failed");
+      const failedCrons = recentCrons.filter((c) => c.status === "failed");
 
       // Indexing
       const [indexed, submitted, neverSubmitted] = await Promise.all([
         prisma.uRLIndexingStatus.count({ where: { site_id: site, status: "indexed" } }),
         prisma.uRLIndexingStatus.count({ where: { site_id: site, submitted_indexnow: true } }),
-        prisma.uRLIndexingStatus.count({ where: { site_id: site, submitted_indexnow: false, submitted_google_api: false } }),
+        prisma.uRLIndexingStatus.count({
+          where: { site_id: site, submitted_indexnow: false, submitted_google_api: false },
+        }),
       ]);
 
       // AI costs (last 7 days)
@@ -161,7 +165,7 @@ server.tool(
         where: { site_id: site, status: { in: ["ready", "queued", "planned", "proposed"] } },
       });
 
-      const phases = Object.fromEntries(phaseCounts.map(p => [p.current_phase, p._count]));
+      const phases = Object.fromEntries(phaseCounts.map((p) => [p.current_phase, p._count]));
 
       return json({
         site,
@@ -176,7 +180,7 @@ server.tool(
         crons: {
           last24h: recentCrons.length,
           failed: failedCrons.length,
-          failedJobs: failedCrons.slice(0, 5).map(c => ({
+          failedJobs: failedCrons.slice(0, 5).map((c) => ({
             job: c.job_name,
             error: c.error_message?.substring(0, 100),
             when: c.started_at,
@@ -194,7 +198,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -217,20 +221,30 @@ server.tool(
       const drafts = await prisma.articleDraft.findMany({
         where: { site_id: site, current_phase: { notIn: ["published", "rejected"] } },
         select: {
-          id: true, keyword: true, current_phase: true, phase_attempts: true,
-          last_error: true, updated_at: true, locale: true, word_count: true, seo_score: true,
+          id: true,
+          keyword: true,
+          current_phase: true,
+          phase_attempts: true,
+          last_error: true,
+          updated_at: true,
+          locale: true,
+          word_count: true,
+          seo_score: true,
         },
         orderBy: { updated_at: "desc" },
         take: 100,
       });
 
-      const stuck24h = drafts.filter(d => d.updated_at < twentyFourHoursAgo);
-      const stuckPipeline = drafts.filter(d => d.updated_at < fourHoursAgo && d.current_phase !== "reservoir");
-      const nearMaxAttempts = drafts.filter(d => (d.phase_attempts || 0) >= 4);
-      const phases = drafts.reduce((acc, d) => {
-        acc[d.current_phase] = (acc[d.current_phase] || 0) + 1;
-        return acc;
-      }, {} as Record<string, number>);
+      const stuck24h = drafts.filter((d) => d.updated_at < twentyFourHoursAgo);
+      const stuckPipeline = drafts.filter((d) => d.updated_at < fourHoursAgo && d.current_phase !== "reservoir");
+      const nearMaxAttempts = drafts.filter((d) => (d.phase_attempts || 0) >= 4);
+      const phases = drafts.reduce(
+        (acc, d) => {
+          acc[d.current_phase] = (acc[d.current_phase] || 0) + 1;
+          return acc;
+        },
+        {} as Record<string, number>,
+      );
 
       // Health grade
       let grade = "A";
@@ -249,24 +263,34 @@ server.tool(
         totalActive: drafts.length,
         phases,
         stuck24h: stuck24h.length,
-        stuckItems: stuck24h.slice(0, 5).map(d => ({
-          keyword: d.keyword, phase: d.current_phase, attempts: d.phase_attempts,
-          error: d.last_error?.substring(0, 80), lastUpdate: d.updated_at,
+        stuckItems: stuck24h.slice(0, 5).map((d) => ({
+          keyword: d.keyword,
+          phase: d.current_phase,
+          attempts: d.phase_attempts,
+          error: d.last_error?.substring(0, 80),
+          lastUpdate: d.updated_at,
         })),
-        nearMaxAttempts: nearMaxAttempts.map(d => ({
-          keyword: d.keyword, phase: d.current_phase, attempts: d.phase_attempts,
+        nearMaxAttempts: nearMaxAttempts.map((d) => ({
+          keyword: d.keyword,
+          phase: d.current_phase,
+          attempts: d.phase_attempts,
         })),
         publishedLast24h: recentPublished,
-        recommendation: grade === "A" ? "Pipeline healthy — no action needed" :
-          grade === "B" ? "Minor delays — monitor, likely self-healing" :
-          grade === "C" ? "Multiple stuck items — consider running diagnose_pipeline" :
-          grade === "D" ? "Pipeline degraded — run diagnose_pipeline now" :
-          "Pipeline stalled — immediate attention needed",
+        recommendation:
+          grade === "A"
+            ? "Pipeline healthy — no action needed"
+            : grade === "B"
+              ? "Minor delays — monitor, likely self-healing"
+              : grade === "C"
+                ? "Multiple stuck items — consider running diagnose_pipeline"
+                : grade === "D"
+                  ? "Pipeline degraded — run diagnose_pipeline now"
+                  : "Pipeline stalled — immediate attention needed",
       });
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -278,7 +302,10 @@ server.tool(
   "List recent articles with title, status, word count, SEO score. Filter by published/draft/all.",
   {
     siteId: z.string().optional().describe("Site ID (default: yalla-london)"),
-    status: z.enum(["published", "draft", "all"]).optional().describe("Filter: published, draft, or all (default: all)"),
+    status: z
+      .enum(["published", "draft", "all"])
+      .optional()
+      .describe("Filter: published, draft, or all (default: all)"),
     limit: z.number().optional().describe("Max results (default: 20, max: 50)"),
   },
   async ({ siteId, status, limit }) => {
@@ -295,10 +322,18 @@ server.tool(
         orderBy: { created_at: "desc" },
         take,
         select: {
-          id: true, title_en: true, slug: true, published: true,
-          seo_score: true, created_at: true, updated_at: true,
-          meta_title_en: true, meta_description_en: true, siteId: true,
-          source_pipeline: true, trace_id: true,
+          id: true,
+          title_en: true,
+          slug: true,
+          published: true,
+          seo_score: true,
+          created_at: true,
+          updated_at: true,
+          meta_title_en: true,
+          meta_description_en: true,
+          siteId: true,
+          source_pipeline: true,
+          trace_id: true,
         },
       });
 
@@ -311,13 +346,13 @@ server.tool(
           });
           const wordCount = full?.content_en ? full.content_en.split(/\s+/).length : 0;
           return { ...a, wordCount };
-        })
+        }),
       );
 
       return json({
         site,
         count: articlesWithCounts.length,
-        articles: articlesWithCounts.map(a => ({
+        articles: articlesWithCounts.map((a) => ({
           title: a.title_en,
           slug: a.slug,
           published: a.published,
@@ -331,7 +366,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -354,7 +389,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -371,7 +406,7 @@ const SAFE_CRONS: Record<string, string> = {
   "content-auto-fix": "/api/cron/content-auto-fix",
   "content-auto-fix-lite": "/api/cron/content-auto-fix-lite",
   "diagnostic-sweep": "/api/cron/diagnostic-sweep",
-  "sweeper": "/api/cron/sweeper",
+  sweeper: "/api/cron/sweeper",
   "affiliate-injection": "/api/cron/affiliate-injection",
   "sync-advertisers": "/api/cron/sync-advertisers",
   "gsc-sync": "/api/cron/gsc-sync",
@@ -384,7 +419,7 @@ const SAFE_CRONS: Record<string, string> = {
   "reserve-publisher": "/api/cron/reserve-publisher",
   "image-pipeline": "/api/cron/image-pipeline",
   "data-refresh": "/api/cron/data-refresh",
-  "analytics": "/api/cron/analytics",
+  analytics: "/api/cron/analytics",
 };
 
 server.tool(
@@ -414,7 +449,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -437,8 +472,12 @@ server.tool(
         orderBy: { started_at: "desc" },
         take: 500,
         select: {
-          job_name: true, status: true, started_at: true,
-          duration_ms: true, error_message: true, items_processed: true,
+          job_name: true,
+          status: true,
+          started_at: true,
+          duration_ms: true,
+          error_message: true,
+          items_processed: true,
         },
       });
 
@@ -452,7 +491,7 @@ server.tool(
 
       const summary = Array.from(byJob.entries()).map(([name, runs]) => {
         const latest = runs[0]!;
-        const failed = runs.filter(r => r.status === "failed").length;
+        const failed = runs.filter((r) => r.status === "failed").length;
         const avgDuration = runs.reduce((s, r) => s + (r.duration_ms || 0), 0) / runs.length;
         return {
           name,
@@ -468,7 +507,7 @@ server.tool(
       summary.sort((a, b) => (b.failures || 0) - (a.failures || 0));
 
       const totalRuns = logs.length;
-      const totalFailed = logs.filter(l => l.status === "failed").length;
+      const totalFailed = logs.filter((l) => l.status === "failed").length;
 
       return json({
         period: `Last ${hours}h`,
@@ -480,7 +519,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -502,8 +541,11 @@ server.tool(
         orderBy: { started_at: "desc" },
         take,
         select: {
-          id: true, status: true, started_at: true,
-          result_summary: true, error_message: true,
+          id: true,
+          status: true,
+          started_at: true,
+          result_summary: true,
+          error_message: true,
         },
       });
 
@@ -521,9 +563,7 @@ server.tool(
         };
       });
 
-      const unresolved = alerts.filter(a =>
-        a.status !== "resolved" && a.status !== "dismissed"
-      );
+      const unresolved = alerts.filter((a) => a.status !== "resolved" && a.status !== "dismissed");
 
       return json({
         totalAlerts: alerts.length,
@@ -533,7 +573,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -563,7 +603,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -586,7 +626,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -607,7 +647,9 @@ server.tool(
       const [indexed, submitted, neverSubmitted, errors, recentSubmissions, chronicFailures] = await Promise.all([
         prisma.uRLIndexingStatus.count({ where: { site_id: site, status: "indexed" } }),
         prisma.uRLIndexingStatus.count({ where: { site_id: site, submitted_indexnow: true } }),
-        prisma.uRLIndexingStatus.count({ where: { site_id: site, submitted_indexnow: false, submitted_google_api: false } }),
+        prisma.uRLIndexingStatus.count({
+          where: { site_id: site, submitted_indexnow: false, submitted_google_api: false },
+        }),
         prisma.uRLIndexingStatus.count({ where: { site_id: site, status: "error" } }),
         prisma.uRLIndexingStatus.findMany({
           where: { site_id: site, last_submitted_at: { gte: weekAgo } },
@@ -632,19 +674,23 @@ server.tool(
         neverSubmitted,
         errors,
         chronicFailures,
-        recentSubmissions: recentSubmissions.map(s => ({
-          url: s.url, status: s.status, submitted: s.last_submitted_at, attempts: s.submission_attempts,
+        recentSubmissions: recentSubmissions.map((s) => ({
+          url: s.url,
+          status: s.status,
+          submitted: s.last_submitted_at,
+          attempts: s.submission_attempts,
         })),
-        recommendation: neverSubmitted > 10
-          ? "Run process-indexing-queue to submit pending pages"
-          : chronicFailures > 5
-            ? "Check IndexNow key file — chronic failures suggest verification issues"
-            : "Indexing pipeline healthy",
+        recommendation:
+          neverSubmitted > 10
+            ? "Run process-indexing-queue to submit pending pages"
+            : chronicFailures > 5
+              ? "Check IndexNow key file — chronic failures suggest verification issues"
+              : "Indexing pipeline healthy",
       });
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -685,39 +731,44 @@ server.tool(
       // Articles missing meta
       const missingMeta = await prisma.blogPost.count({
         where: {
-          siteId: site, published: true,
-          OR: [
-            { meta_title_en: { equals: "" } },
-            { meta_description_en: { equals: "" } },
-          ],
+          siteId: site,
+          published: true,
+          OR: [{ meta_title_en: { equals: "" } }, { meta_description_en: { equals: "" } }],
         },
       });
 
       return json({
         site,
-        lastSeoAgentRun: latestSeoAgent ? {
-          when: latestSeoAgent.started_at,
-          duration: `${latestSeoAgent.duration_ms}ms`,
-          result: latestSeoAgent.result_summary,
-        } : null,
-        lastDeepReview: latestDeepReview ? {
-          when: latestDeepReview.started_at,
-          result: latestDeepReview.result_summary,
-        } : null,
-        lowSeoArticles: lowSeoArticles.map(a => ({
-          title: a.title_en, slug: a.slug, score: a.seo_score,
+        lastSeoAgentRun: latestSeoAgent
+          ? {
+              when: latestSeoAgent.started_at,
+              duration: `${latestSeoAgent.duration_ms}ms`,
+              result: latestSeoAgent.result_summary,
+            }
+          : null,
+        lastDeepReview: latestDeepReview
+          ? {
+              when: latestDeepReview.started_at,
+              result: latestDeepReview.result_summary,
+            }
+          : null,
+        lowSeoArticles: lowSeoArticles.map((a) => ({
+          title: a.title_en,
+          slug: a.slug,
+          score: a.seo_score,
         })),
         missingMetaCount: missingMeta,
-        recommendation: lowSeoArticles.length > 5
-          ? "Multiple articles below SEO threshold — run seo-deep-review"
-          : missingMeta > 0
-            ? `${missingMeta} articles missing meta tags — seo-agent will auto-fix`
-            : "SEO health looks good",
+        recommendation:
+          lowSeoArticles.length > 5
+            ? "Multiple articles below SEO threshold — run seo-deep-review"
+            : missingMeta > 0
+              ? `${missingMeta} articles missing meta tags — seo-agent will auto-fix`
+              : "SEO health looks good",
       });
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -761,7 +812,8 @@ server.tool(
       // Coverage: articles with affiliate links vs total
       const withAffiliates = await prisma.blogPost.count({
         where: {
-          siteId: site, published: true,
+          siteId: site,
+          published: true,
           content_en: { contains: "affiliate" },
         },
       });
@@ -781,19 +833,21 @@ server.tool(
           totalPublished: publishedCount,
           rate: `${coverageRate}%`,
         },
-        topArticles: topArticles.map(a => ({
-          slug: a.articleSlug, clicks: a._count,
+        topArticles: topArticles.map((a) => ({
+          slug: a.articleSlug,
+          clicks: a._count,
         })),
-        recommendation: coverageRate < 50
-          ? "Low affiliate coverage — run affiliate-injection cron"
-          : clicksRecent === 0
-            ? "Zero clicks — check if affiliate links are visible on articles"
-            : "Affiliate pipeline active",
+        recommendation:
+          coverageRate < 50
+            ? "Low affiliate coverage — run affiliate-injection cron"
+            : clicksRecent === 0
+              ? "Zero clicks — check if affiliate links are visible on articles"
+              : "Affiliate pipeline active",
       });
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -867,12 +921,12 @@ server.tool(
           tokens: costsMonth._sum.totalTokens || 0,
           calls: costsMonth._count,
         },
-        byProvider: byProvider.map(p => ({
+        byProvider: byProvider.map((p) => ({
           provider: p.provider,
           cost: `$${(p._sum.estimatedCostUsd || 0).toFixed(4)}`,
           calls: p._count,
         })),
-        byTask: byTask.map(t => ({
+        byTask: byTask.map((t) => ({
           task: t.taskType,
           cost: `$${(t._sum.estimatedCostUsd || 0).toFixed(4)}`,
           calls: t._count,
@@ -881,7 +935,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -909,32 +963,55 @@ server.tool(
           prisma.crmOpportunity.findFirst({ where: { contactEmail: email } }),
         ]);
 
-        if (lead) results.lead = {
-          name: lead.name, email: lead.email, status: lead.status,
-          score: lead.score, source: lead.lead_source, created: lead.created_at,
-        };
-        if (subscriber) results.subscriber = {
-          email: subscriber.email, status: subscriber.status, created: subscriber.created_at,
-        };
-        if (inquiry) results.charterInquiry = {
-          email: inquiry.email, firstName: inquiry.firstName,
-          yachtType: inquiry.yachtType, status: inquiry.status, created: inquiry.createdAt,
-        };
-        if (opportunity) results.opportunity = {
-          stage: opportunity.stage, value: opportunity.value,
-          source: opportunity.source, nextAction: opportunity.nextAction, created: opportunity.createdAt,
-        };
+        if (lead)
+          results.lead = {
+            name: lead.name,
+            email: lead.email,
+            status: lead.status,
+            score: lead.score,
+            source: lead.lead_source,
+            created: lead.created_at,
+          };
+        if (subscriber)
+          results.subscriber = {
+            email: subscriber.email,
+            status: subscriber.status,
+            created: subscriber.created_at,
+          };
+        if (inquiry)
+          results.charterInquiry = {
+            email: inquiry.email,
+            firstName: inquiry.firstName,
+            yachtType: inquiry.yachtType,
+            status: inquiry.status,
+            created: inquiry.createdAt,
+          };
+        if (opportunity)
+          results.opportunity = {
+            stage: opportunity.stage,
+            value: opportunity.value,
+            source: opportunity.source,
+            nextAction: opportunity.nextAction,
+            created: opportunity.createdAt,
+          };
       }
 
       if (phone) {
         const lead = await prisma.lead.findFirst({ where: { phone } });
         const inquiry = await prisma.charterInquiry.findFirst({ where: { phone } });
-        if (lead) results.leadByPhone = {
-          name: lead.name, email: lead.email, status: lead.status, score: lead.score,
-        };
-        if (inquiry) results.inquiryByPhone = {
-          email: inquiry.email, firstName: inquiry.firstName, status: inquiry.status,
-        };
+        if (lead)
+          results.leadByPhone = {
+            name: lead.name,
+            email: lead.email,
+            status: lead.status,
+            score: lead.score,
+          };
+        if (inquiry)
+          results.inquiryByPhone = {
+            email: inquiry.email,
+            firstName: inquiry.firstName,
+            status: inquiry.status,
+          };
       }
 
       const found = Object.keys(results).length > 0;
@@ -946,7 +1023,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -999,7 +1076,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1022,9 +1099,7 @@ server.tool(
     try {
       const where: Record<string, unknown> = { site_id: site };
       if (targetStatus !== "all") {
-        where.status = targetStatus === "ready"
-          ? { in: ["ready", "queued", "planned", "proposed"] }
-          : targetStatus;
+        where.status = targetStatus === "ready" ? { in: ["ready", "queued", "planned", "proposed"] } : targetStatus;
       }
 
       const topics = await prisma.topicProposal.findMany({
@@ -1032,9 +1107,15 @@ server.tool(
         orderBy: { created_at: "desc" },
         take,
         select: {
-          id: true, title: true, status: true, locale: true,
-          primary_keyword: true, intent: true, confidence_score: true,
-          suggested_page_type: true, created_at: true,
+          id: true,
+          title: true,
+          status: true,
+          locale: true,
+          primary_keyword: true,
+          intent: true,
+          confidence_score: true,
+          suggested_page_type: true,
+          created_at: true,
         },
       });
 
@@ -1049,8 +1130,8 @@ server.tool(
         site,
         filter: targetStatus,
         count: topics.length,
-        statusSummary: Object.fromEntries(statusCounts.map(s => [s.status, s._count])),
-        topics: topics.map(t => ({
+        statusSummary: Object.fromEntries(statusCounts.map((s) => [s.status, s._count])),
+        topics: topics.map((t) => ({
           id: t.id,
           title: t.title,
           status: t.status,
@@ -1065,7 +1146,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1093,7 +1174,11 @@ server.tool(
 
       const text = await res.text();
       let data: unknown;
-      try { data = JSON.parse(text); } catch { data = text; }
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = text;
+      }
 
       return json({
         action: "research_topics",
@@ -1105,7 +1190,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1126,7 +1211,9 @@ server.tool(
         sites.map(async (site) => {
           const [published, drafts, reservoir, indexed, clicks, aiCost] = await Promise.all([
             prisma.blogPost.count({ where: { siteId: site, published: true } }),
-            prisma.articleDraft.count({ where: { site_id: site, current_phase: { notIn: ["published", "rejected"] } } }),
+            prisma.articleDraft.count({
+              where: { site_id: site, current_phase: { notIn: ["published", "rejected"] } },
+            }),
             prisma.articleDraft.count({ where: { site_id: site, current_phase: "reservoir" } }),
             prisma.uRLIndexingStatus.count({ where: { site_id: site, status: "indexed" } }),
             prisma.cjClickEvent.count({ where: { OR: [{ siteId: site }, { siteId: null }] } }),
@@ -1143,14 +1230,14 @@ server.tool(
             revenue: { affiliateClicks: clicks },
             aiCost7d: `$${(aiCost._sum.estimatedCostUsd || 0).toFixed(4)}`,
           };
-        })
+        }),
       );
 
       return json({ sites: metrics });
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1173,7 +1260,7 @@ server.tool(
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1197,7 +1284,11 @@ server.tool(
       const [publishedRecent, draftsStuck, reservoirCount] = await Promise.all([
         prisma.blogPost.count({ where: { siteId: site, published: true, created_at: { gte: twentyFourHoursAgo } } }),
         prisma.articleDraft.count({
-          where: { site_id: site, current_phase: { notIn: ["published", "rejected", "reservoir"] }, updated_at: { lt: twelveHoursAgo } },
+          where: {
+            site_id: site,
+            current_phase: { notIn: ["published", "rejected", "reservoir"] },
+            updated_at: { lt: twelveHoursAgo },
+          },
         }),
         prisma.articleDraft.count({ where: { site_id: site, current_phase: "reservoir" } }),
       ]);
@@ -1208,7 +1299,7 @@ server.tool(
         select: { status: true, job_name: true, error_message: true },
       });
       const cronTotal = cronLogs.length;
-      const cronFailed = cronLogs.filter(c => c.status === "failed").length;
+      const cronFailed = cronLogs.filter((c) => c.status === "failed").length;
       const successRate = cronTotal > 0 ? Math.round(((cronTotal - cronFailed) / cronTotal) * 100) : 0;
 
       // AI provider health
@@ -1228,28 +1319,61 @@ server.tool(
       const issues: { severity: string; category: string; description: string; fix: string }[] = [];
 
       if (publishedRecent === 0) {
-        issues.push({ severity: "high", category: "pipeline", description: "Zero articles published in 24h", fix: "Run publish_ready or diagnose_pipeline" });
+        issues.push({
+          severity: "high",
+          category: "pipeline",
+          description: "Zero articles published in 24h",
+          fix: "Run publish_ready or diagnose_pipeline",
+        });
       }
       if (draftsStuck > 5) {
-        issues.push({ severity: "high", category: "pipeline", description: `${draftsStuck} drafts stuck for 12h+`, fix: "Run diagnose_pipeline" });
+        issues.push({
+          severity: "high",
+          category: "pipeline",
+          description: `${draftsStuck} drafts stuck for 12h+`,
+          fix: "Run diagnose_pipeline",
+        });
       }
       if (reservoirCount > 50) {
-        issues.push({ severity: "medium", category: "pipeline", description: `Reservoir overflow: ${reservoirCount} articles`, fix: "Run publish_ready to drain reservoir" });
+        issues.push({
+          severity: "medium",
+          category: "pipeline",
+          description: `Reservoir overflow: ${reservoirCount} articles`,
+          fix: "Run publish_ready to drain reservoir",
+        });
       }
       if (successRate < 80) {
-        issues.push({ severity: "high", category: "crons", description: `Cron success rate only ${successRate}%`, fix: "Check cron_health for failing jobs" });
+        issues.push({
+          severity: "high",
+          category: "crons",
+          description: `Cron success rate only ${successRate}%`,
+          fix: "Check cron_health for failing jobs",
+        });
       }
       for (const [provider, health] of providerHealth) {
         const rate = health.total > 0 ? (health.success / health.total) * 100 : 0;
         if (rate < 50 && health.total >= 3) {
-          issues.push({ severity: "medium", category: "ai", description: `${provider} failing ${Math.round(100 - rate)}% of calls`, fix: "Check API key / quota" });
+          issues.push({
+            severity: "medium",
+            category: "ai",
+            description: `${provider} failing ${Math.round(100 - rate)}% of calls`,
+            fix: "Check API key / quota",
+          });
         }
       }
 
       // Overall grade
-      const criticalCount = issues.filter(i => i.severity === "high").length;
-      const grade = criticalCount === 0 ? (issues.length === 0 ? "A" : "B") :
-        criticalCount <= 2 ? "C" : criticalCount <= 4 ? "D" : "F";
+      const criticalCount = issues.filter((i) => i.severity === "high").length;
+      const grade =
+        criticalCount === 0
+          ? issues.length === 0
+            ? "A"
+            : "B"
+          : criticalCount <= 2
+            ? "C"
+            : criticalCount <= 4
+              ? "D"
+              : "F";
 
       return json({
         site,
@@ -1264,19 +1388,26 @@ server.tool(
           cronFailed,
         },
         aiProviders: Object.fromEntries(
-          Array.from(providerHealth.entries()).map(([p, h]) => [p, {
-            calls: h.total, successRate: `${h.total > 0 ? Math.round((h.success / h.total) * 100) : 0}%`,
-          }])
+          Array.from(providerHealth.entries()).map(([p, h]) => [
+            p,
+            {
+              calls: h.total,
+              successRate: `${h.total > 0 ? Math.round((h.success / h.total) * 100) : 0}%`,
+            },
+          ]),
         ),
         issues,
-        recommendation: grade === "A" ? "Everything running smoothly" :
-          grade === "B" ? "Minor issues — self-healing systems should resolve" :
-          "Action needed — check issues above",
+        recommendation:
+          grade === "A"
+            ? "Everything running smoothly"
+            : grade === "B"
+              ? "Minor issues — self-healing systems should resolve"
+              : "Action needed — check issues above",
       });
     } catch (err: unknown) {
       return error(err instanceof Error ? err.message : String(err));
     }
-  }
+  },
 );
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1302,7 +1433,11 @@ server.tool(
         orderBy: { created_at: "desc" },
         take,
         select: {
-          id: true, slug: true, title_en: true, seo_score: true, created_at: true,
+          id: true,
+          slug: true,
+          title_en: true,
+          seo_score: true,
+          created_at: true,
         },
       });
       const urls = posts.map((p) => `${domain}/blog/${p.slug}`);
@@ -1351,10 +1486,19 @@ server.tool(
       const post = await prisma.blogPost.findUnique({
         where: { id: pageId },
         select: {
-          id: true, siteId: true, slug: true, title_en: true, title_ar: true,
-          content_en: true, meta_title_en: true, meta_description_en: true,
-          seo_score: true, published: true, created_at: true,
-          source_pipeline: true, enhancement_log: true,
+          id: true,
+          siteId: true,
+          slug: true,
+          title_en: true,
+          title_ar: true,
+          content_en: true,
+          meta_title_en: true,
+          meta_description_en: true,
+          seo_score: true,
+          published: true,
+          created_at: true,
+          source_pipeline: true,
+          enhancement_log: true,
         },
       });
       if (!post) return error(`Page not found: ${pageId}`);
@@ -1372,8 +1516,12 @@ server.tool(
         prisma.uRLIndexingStatus.findFirst({
           where: { site_id: post.siteId || undefined, url },
           select: {
-            status: true, coverage_state: true, indexing_state: true,
-            submission_attempts: true, last_inspected_at: true, last_error: true,
+            status: true,
+            coverage_state: true,
+            indexing_state: true,
+            submission_attempts: true,
+            last_inspected_at: true,
+            last_error: true,
           },
         }),
       ]);
@@ -1385,9 +1533,13 @@ server.tool(
 
       return json({
         page: {
-          id: post.id, url, title: post.title_en,
+          id: post.id,
+          url,
+          title: post.title_en,
           seoScore: post.seo_score ?? undefined,
-          wordCount, internalLinkCount, affiliateLinkCount,
+          wordCount,
+          internalLinkCount,
+          affiliateLinkCount,
           metaTitleEn: post.meta_title_en ?? undefined,
           metaDescriptionEn: post.meta_description_en ?? undefined,
           published: post.published,
@@ -1430,8 +1582,12 @@ server.tool(
           orderBy: { started_at: "desc" },
           take: 100,
           select: {
-            job_name: true, status: true, started_at: true, duration_ms: true,
-            items_failed: true, error_message: true,
+            job_name: true,
+            status: true,
+            started_at: true,
+            duration_ms: true,
+            items_failed: true,
+            error_message: true,
           },
         }),
         prisma.autoFixLog.count({
@@ -1497,12 +1653,25 @@ server.tool(
           "Content-Type": "application/json",
           ...(secret ? { Authorization: `Bearer ${secret}` } : {}),
         },
-        body: JSON.stringify({ siteId, pageUrl, auditType, severity, findings, interpretedActions, reportMarkdown, rawData }),
+        body: JSON.stringify({
+          siteId,
+          pageUrl,
+          auditType,
+          severity,
+          findings,
+          interpretedActions,
+          reportMarkdown,
+          rawData,
+        }),
         signal: AbortSignal.timeout(55_000),
       });
       const text = await res.text();
       let data: unknown;
-      try { data = JSON.parse(text); } catch { data = text; }
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = text;
+      }
       if (!res.ok) return error(`Upload failed: ${res.status} ${JSON.stringify(data).slice(0, 500)}`);
       return json(data);
     } catch (err: unknown) {
@@ -1538,7 +1707,11 @@ server.tool(
       });
       const text = await res.text();
       let data: unknown;
-      try { data = JSON.parse(text); } catch { data = text; }
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = text;
+      }
       if (!res.ok) return error(`Upload failed: ${res.status} ${JSON.stringify(data).slice(0, 500)}`);
       return json(data);
     } catch (err: unknown) {
@@ -1569,9 +1742,16 @@ server.tool(
         orderBy: { uploadedAt: "desc" },
         take,
         select: {
-          id: true, siteId: true, pageUrl: true, pageSlug: true,
-          auditType: true, severity: true, status: true,
-          uploadedAt: true, reviewedAt: true, fixedAt: true,
+          id: true,
+          siteId: true,
+          pageUrl: true,
+          pageSlug: true,
+          auditType: true,
+          severity: true,
+          status: true,
+          uploadedAt: true,
+          reviewedAt: true,
+          fixedAt: true,
           agentTaskId: true,
         },
       });
@@ -1585,11 +1765,333 @@ server.tool(
   },
 );
 
+// ═══════════════════════════════════════════════════════════════════════════
+// AFFILIATE MONITORING
+// ═══════════════════════════════════════════════════════════════════════════
+
+server.tool(
+  "affiliate_link_health",
+  "Audit every affiliate link in published articles. Detects dead links (HTTP 4xx/5xx), untracked direct partner URLs (bypassing /api/affiliate/click), stale year references, and missing SID attribution. Per-article breakdown.",
+  {
+    siteId: z.string().optional().describe("Site ID (default: yalla-london)"),
+    maxArticles: z.number().optional().describe("Max articles to scan (default: 50)"),
+    skipLiveness: z.boolean().optional().describe("Skip HTTP HEAD checks for speed (default: false)"),
+  },
+  async ({ siteId, maxArticles, skipLiveness }) => {
+    try {
+      const { runLinkHealthAudit } = await import("@/lib/affiliate/link-auditor");
+      const result = await runLinkHealthAudit({
+        siteId: siteId || getDefaultSiteId(),
+        maxArticles: maxArticles || 50,
+        skipLiveness: skipLiveness ?? false,
+      });
+      return json(result);
+    } catch (err: unknown) {
+      return error(err instanceof Error ? err.message : String(err));
+    }
+  },
+);
+
+server.tool(
+  "affiliate_coverage",
+  "Show which published articles have affiliate links and which don't. Returns coverage % and the list of uncovered articles (candidates for affiliate-injection cron).",
+  {
+    siteId: z.string().optional().describe("Site ID (default: yalla-london)"),
+  },
+  async ({ siteId }) => {
+    try {
+      const { getContentCoverage } = await import("@/lib/affiliate/monitor");
+      const result = await getContentCoverage(siteId || getDefaultSiteId());
+      return json(result);
+    } catch (err: unknown) {
+      return error(err instanceof Error ? err.message : String(err));
+    }
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// IMAGE FIXES
+// ═══════════════════════════════════════════════════════════════════════════
+
+server.tool(
+  "image_audit",
+  "Find image issues across published articles: missing featured image, <img> tags without alt text, suspicious stock-photo hostnames. Read-only.",
+  {
+    siteId: z.string().optional().describe("Site ID (default: yalla-london)"),
+    limit: z.number().optional().describe("Max articles to return per issue type (default: 25)"),
+  },
+  async ({ siteId, limit }) => {
+    const site = siteId || getDefaultSiteId();
+    const cap = Math.min(limit || 25, 100);
+    try {
+      const posts = await prisma.blogPost.findMany({
+        where: { siteId: site, published: true },
+        select: { id: true, slug: true, title_en: true, featured_image: true, content_en: true },
+        take: 500,
+      });
+
+      const missingFeatured: Array<{ slug: string; title: string }> = [];
+      const missingAlt: Array<{ slug: string; title: string; imgCount: number }> = [];
+      const suspiciousHosts: Array<{ slug: string; title: string; hosts: string[] }> = [];
+      const suspiciousHostPattern = /(istockphoto|shutterstock|gettyimages|adobestock|123rf|dreamstime|stock\.adobe)/i;
+
+      for (const p of posts) {
+        if (!p.featured_image || p.featured_image.trim() === "") {
+          missingFeatured.push({ slug: p.slug, title: p.title_en?.slice(0, 80) || "(no title)" });
+        }
+        const content = p.content_en || "";
+        const imgMatches = [...content.matchAll(/<img\b[^>]*>/gi)];
+        const imgsWithoutAlt = imgMatches.filter((m) => !/\balt\s*=\s*"[^"]+"/i.test(m[0]));
+        if (imgsWithoutAlt.length > 0) {
+          missingAlt.push({
+            slug: p.slug,
+            title: p.title_en?.slice(0, 80) || "(no title)",
+            imgCount: imgsWithoutAlt.length,
+          });
+        }
+        const srcMatches = [...content.matchAll(/<img\b[^>]*\bsrc\s*=\s*"([^"]+)"/gi)];
+        const hosts = new Set<string>();
+        for (const m of srcMatches) {
+          try {
+            const u = new URL(m[1]);
+            if (suspiciousHostPattern.test(u.hostname)) hosts.add(u.hostname);
+          } catch {
+            /* relative URL — ignore */
+          }
+        }
+        if (hosts.size > 0) {
+          suspiciousHosts.push({ slug: p.slug, title: p.title_en?.slice(0, 80) || "(no title)", hosts: [...hosts] });
+        }
+      }
+
+      return json({
+        site,
+        totalScanned: posts.length,
+        summary: {
+          missingFeaturedImage: missingFeatured.length,
+          articlesWithImagesMissingAlt: missingAlt.length,
+          articlesWithSuspiciousHosts: suspiciousHosts.length,
+        },
+        missingFeaturedImage: missingFeatured.slice(0, cap),
+        missingAlt: missingAlt.slice(0, cap),
+        suspiciousHosts: suspiciousHosts.slice(0, cap),
+        nextStep:
+          missingFeatured.length > 0 || suspiciousHosts.length > 0
+            ? "Run image_fix to trigger image-pipeline cron"
+            : "All checks passed",
+      });
+    } catch (err: unknown) {
+      return error(err instanceof Error ? err.message : String(err));
+    }
+  },
+);
+
+server.tool(
+  "image_fix",
+  "Trigger the image-pipeline cron — fills missing featured images from Unsplash/Hotellook, replaces blocked stock photos. Write operation.",
+  {},
+  async () => {
+    const result = await callCron("/api/cron/image-pipeline");
+    return json(result);
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// DATES CLEANUP
+// ═══════════════════════════════════════════════════════════════════════════
+
+server.tool(
+  "dates_audit",
+  "Find published articles with stale year references in title or meta tags. Lists articles where the year embedded in copy is older than the current year (e.g., '...2024 Guide' published in 2026). Read-only.",
+  {
+    siteId: z.string().optional().describe("Site ID (default: yalla-london)"),
+    limit: z.number().optional().describe("Max articles to return (default: 50)"),
+  },
+  async ({ siteId, limit }) => {
+    const site = siteId || getDefaultSiteId();
+    const cap = Math.min(limit || 50, 200);
+    const currentYear = new Date().getFullYear();
+    try {
+      const posts = await prisma.blogPost.findMany({
+        where: { siteId: site, published: true },
+        select: {
+          id: true,
+          slug: true,
+          created_at: true,
+          title_en: true,
+          title_ar: true,
+          meta_title_en: true,
+          meta_title_ar: true,
+          meta_description_en: true,
+          meta_description_ar: true,
+        },
+        orderBy: { created_at: "desc" },
+        take: 1000,
+      });
+
+      const stale: Array<{
+        slug: string;
+        createdAt: string;
+        staleYears: number[];
+        staleFields: string[];
+        title_en: string;
+      }> = [];
+
+      const yearRegex = /\b(20\d{2})\b/g;
+      const fields: Array<keyof (typeof posts)[0]> = [
+        "title_en",
+        "title_ar",
+        "meta_title_en",
+        "meta_title_ar",
+        "meta_description_en",
+        "meta_description_ar",
+      ];
+
+      for (const p of posts) {
+        const staleYears = new Set<number>();
+        const staleFields = new Set<string>();
+        for (const f of fields) {
+          const v = (p[f] as string | null) || "";
+          for (const m of v.matchAll(yearRegex)) {
+            const y = parseInt(m[1], 10);
+            if (y >= 2018 && y < currentYear) {
+              staleYears.add(y);
+              staleFields.add(f as string);
+            }
+          }
+        }
+        if (staleYears.size > 0) {
+          stale.push({
+            slug: p.slug,
+            createdAt: p.created_at.toISOString().slice(0, 10),
+            staleYears: [...staleYears].sort(),
+            staleFields: [...staleFields],
+            title_en: (p.title_en || "").slice(0, 100),
+          });
+        }
+      }
+
+      return json({
+        site,
+        currentYear,
+        totalScanned: posts.length,
+        staleCount: stale.length,
+        stale: stale.slice(0, cap),
+        nextStep:
+          stale.length > 0
+            ? "Bulk title/meta refresh: rewrite each title replacing the stale year with the current year. Can be done via bulk-publish or manual editor edits."
+            : "All dates current",
+      });
+    } catch (err: unknown) {
+      return error(err instanceof Error ? err.message : String(err));
+    }
+  },
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// INTERNAL LINKS
+// ═══════════════════════════════════════════════════════════════════════════
+
+server.tool(
+  "internal_links_audit",
+  "Find orphan and under-linked published articles. Orphan = zero inbound internal links (no other article links to it). Under-linked = fewer than 3 outbound internal links in body. Read-only.",
+  {
+    siteId: z.string().optional().describe("Site ID (default: yalla-london)"),
+    minOutbound: z.number().optional().describe("Outbound link threshold (default: 3)"),
+  },
+  async ({ siteId, minOutbound }) => {
+    const site = siteId || getDefaultSiteId();
+    const minOut = minOutbound || 3;
+    try {
+      const posts = await prisma.blogPost.findMany({
+        where: { siteId: site, published: true },
+        select: { id: true, slug: true, title_en: true, content_en: true, created_at: true },
+        take: 1000,
+      });
+
+      // Build inbound-link map by scanning every article's content for /blog/<slug>
+      const inboundCount = new Map<string, number>();
+      for (const p of posts) inboundCount.set(p.slug, 0);
+
+      const outboundCounts = new Map<string, number>();
+      const slugLinkRe = /\/blog\/([a-z0-9-]+)/gi;
+
+      for (const p of posts) {
+        const content = p.content_en || "";
+        const referencedSlugs = new Set<string>();
+        for (const m of content.matchAll(slugLinkRe)) {
+          const target = m[1];
+          if (target !== p.slug) referencedSlugs.add(target);
+        }
+        outboundCounts.set(p.slug, referencedSlugs.size);
+        for (const s of referencedSlugs) {
+          if (inboundCount.has(s)) inboundCount.set(s, (inboundCount.get(s) || 0) + 1);
+        }
+      }
+
+      const orphans: Array<{ slug: string; title: string; createdAt: string }> = [];
+      const underLinked: Array<{ slug: string; title: string; outbound: number }> = [];
+
+      for (const p of posts) {
+        if ((inboundCount.get(p.slug) || 0) === 0) {
+          orphans.push({
+            slug: p.slug,
+            title: (p.title_en || "").slice(0, 80),
+            createdAt: p.created_at.toISOString().slice(0, 10),
+          });
+        }
+        if ((outboundCounts.get(p.slug) || 0) < minOut) {
+          underLinked.push({
+            slug: p.slug,
+            title: (p.title_en || "").slice(0, 80),
+            outbound: outboundCounts.get(p.slug) || 0,
+          });
+        }
+      }
+
+      return json({
+        site,
+        totalScanned: posts.length,
+        summary: {
+          orphans: orphans.length,
+          underLinked: underLinked.length,
+          minOutboundThreshold: minOut,
+        },
+        orphans: orphans.slice(0, 50),
+        underLinked: underLinked.slice(0, 50),
+        nextStep:
+          orphans.length + underLinked.length > 0
+            ? "Run internal_links_inject to trigger seo-agent's related-article injection batch"
+            : "All articles meet linking thresholds",
+      });
+    } catch (err: unknown) {
+      return error(err instanceof Error ? err.message : String(err));
+    }
+  },
+);
+
+server.tool(
+  "internal_links_inject",
+  "Trigger the seo-agent cron — injects related-article links into under-linked published articles + cleans broken/placeholder slugs. Write operation.",
+  {},
+  async () => {
+    const result = await callCron("/api/cron/seo-agent");
+    return json(result);
+  },
+);
+
 // ---------------------------------------------------------------------------
 // Start server
 // ---------------------------------------------------------------------------
 
 async function main() {
+  // Surface a clean error early if DATABASE_URL is missing rather than crashing
+  // mid-tool with a Prisma engine error.
+  if (!process.env.DATABASE_URL) {
+    console.error(
+      "[platform-control] DATABASE_URL is not set. The MCP server will start, but every tool that touches the DB will fail. Set DATABASE_URL in yalla_london/app/.env.local or in the .mcp.json env block.",
+    );
+  }
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/yalla_london/app/scripts/mcp-platform-server.ts
+++ b/yalla_london/app/scripts/mcp-platform-server.ts
@@ -2080,6 +2080,29 @@ server.tool(
   },
 );
 
+// ═══════════════════════════════════════════════════════════════════════════
+// PUBLIC WEBSITE AUDIT
+// ═══════════════════════════════════════════════════════════════════════════
+
+server.tool(
+  "public_audit",
+  "Run the full 6-dimension public-website audit (photos, unedited content, news refresh, SEO updates, AIO alignment, affiliate practices) against published articles. Returns overall grade A-F, score, top actions ranked by severity, and per-dimension breakdown with score + top issues. Same engine as the /api/admin/public-audit endpoint — no HTTP round-trip.",
+  {
+    siteId: z.string().optional().describe("Site ID (default: yalla-london)"),
+    sample: z.number().optional().describe("Max articles to scan (default: 500, capped 50-1000)"),
+  },
+  async ({ siteId, sample }) => {
+    try {
+      const { runPublicAudit } = await import("@/app/api/admin/public-audit/route");
+      const start = Date.now();
+      const report = await runPublicAudit(siteId || getDefaultSiteId(), sample || 500);
+      return json({ ...report, durationMs: Date.now() - start });
+    } catch (err: unknown) {
+      return error(err instanceof Error ? err.message : String(err));
+    }
+  },
+);
+
 // ---------------------------------------------------------------------------
 // Start server
 // ---------------------------------------------------------------------------

--- a/yalla_london/app/vercel.json
+++ b/yalla_london/app/vercel.json
@@ -85,6 +85,9 @@
     "app/api/cron/diagnostic-sweep/**/*.ts": {
       "maxDuration": 300
     },
+    "app/api/cron/audit-roundup/**/*.ts": {
+      "maxDuration": 300
+    },
     "app/api/cron/google-indexing/**/*.ts": {
       "maxDuration": 300
     },
@@ -284,6 +287,10 @@
     {
       "path": "/api/cron/diagnostic-sweep",
       "schedule": "55 1,3,5,7,9,11,13,15,17,19,21,23 * * *"
+    },
+    {
+      "path": "/api/cron/audit-roundup",
+      "schedule": "0 7,19 * * *"
     },
     {
       "path": "/api/cron/pipeline-health",


### PR DESCRIPTION
The aggregated report was reporting vague counts ("2 articles share duplicate
titles", "1 page failed to index after 5+ attempts", "3 cron failures") without
identifying WHICH articles or WHAT errors. Khaled couldn't act from his phone.

Changes
- Extend `auditFindings` type to preserve `affected[]` from seo-audit (was
  silently dropped at the cast). Slugs for duplicate titles + URLs for chronic
  indexing failures now flow through to the issues array.
- New `operations.failedCronDetails[]` field — captures latest error_message
  per failed cron name (de-duped from a 100-row recent slice).
- Issue payloads now include `affected[]` (top 15 entries) when present.
- Plain-language output adds bullet sub-rows under each issue and per-cron
  error snippets under "Failed:".

Why this matters
- Same Vercel cron, same DB queries — no infrastructure cost.
- Khaled now sees actual slugs / URLs / error strings on the iPhone view,
  not just opaque counts.
- Re-uses data the seo-audit already persists in `SeoAuditReport.findings`
  (it was being dropped by a typed cast that omitted `affected`).

Verification
- `tsc --noEmit` clean (zero errors).
- No schema changes, no new queries against tables that weren't already
  queried in the same handler.