### PR TITLE
docs(audit): M3.5 handoff document for Yalla London redesign

### DIFF
--- a/docs/audit/m3.5-handoff.md
+++ b/docs/audit/m3.5-handoff.md
@@ -1,0 +1,943 @@
+# Yalla London — M3.5 Handoff Audit Document
+
+**Status: COMPLETE** | Cannot-answer count: 8 | API spend: $0.00 | Generated in ~01:15
+
+## 5-bullet summary (read this first)
+
+- **Production is unreachable.** `https://yalla-london.com/` and `https://www.yalla-london.com/` return HTTP **403 with `x-deny-reason: host_not_allowed`** — served by an upstream layer (IP `216.150.1.193`) before requests reach the Next.js app. The string `host_not_allowed` does not appear anywhere in the repo, so the deny is happening above the application. The sister domain `zenithayachts.com` resolves to the same IP and returns the same 403. `docs/HEALTH-PROBE-RESULTS.md` (dated 2026-03-15) recorded **0/19 endpoints reachable** ~53 days ago, suggesting this is not a new outage. The M3.5 redesign cannot be validated against a live site until this is resolved.
+- **The codebase is healthy and modern.** Next.js 14.2.32 (App Router) + React 18.2 + TypeScript 5.2 + Prisma 6.16 + Tailwind 3.3 + 28 Radix UI primitives + framer-motion + lucide-react. 191 App Router routes total (~80 public-facing, ~111 under `/admin`). Self-hosted Google fonts via `next/font` (no render-blocking external CSS). Image optimization enabled with avif/webp output. All public pages have `generateMetadata()` with canonical + hreflang. Bilingual EN/AR with `/ar/*` URL prefix (not subdomain, not query, not cookie).
+- **URL grammar is settled and must be preserved.** Blog posts at `/blog/<slug>`, Arabic at `/ar/blog/<slug>`. 14 hash-suffix duplicate slugs are 301-redirected via `lib/seo/redirect-map.ts → BLOG_REDIRECTS`. One static-page redirect exists (`/luxury-hotels-london` → `/hotels`). 24 static "pillar" routes are guaranteed in every sitemap. M3.5 must keep this grammar exactly.
+- **Recent operator activity is a "quality reset" against duplicate clusters.** The last 30 commits center on `clean-slate analyzer/executor`, `CONTENT_GENERATION_PAUSE` master kill-switch, topic-discipline gates in `weekly-topics`, and a March commit titled "yalla-london Grade F → recoverable — sitemap self-heal + threshold realism". CLAUDE.md (April 30, 2026) records the strategic context: 239 published articles, 22 indexed by Google, ~3 organic clicks/week, root cause classified as topical dilution (12+ "Best Halal Restaurants" near-duplicates), not code bugs. M3.5 must accommodate the consolidation that is in progress.
+- **Migration risk areas the M3.5 work should not break.** (1) The 14 BLOG_REDIRECTS map plus 1 PAGE_REDIRECT — every entry must keep its 301 target reachable. (2) The 24 static pillar URLs in the sitemap fallback. (3) Hreflang reciprocity between EN root and `/ar/*` — every public page emits `en-GB` + `ar-SA` + `x-default` via `getLocaleAlternates()`. (4) The cache-first sitemap design (`SiteSettings` row written every 4h by `content-auto-fix-lite`). (5) Cookie consent + GDPR endpoints (`/api/gdpr/delete`). (6) Rate-limit middleware (5/15min on auth, 3/min heavy AI, 20/min mutations, 60/min reads). (7) The `BlogPost.canonical_slug` redirect column.
+
+---
+
+## Section 0 — Metadata
+
+| Field | Value |
+|---|---|
+| Generated | `2026-05-07T14:16:08Z` |
+| Repo path | `/home/user/Yalla-london` |
+| Deployed app subpath | `yalla_london/app/` |
+| Git branch | `claude/yalla-london-audit-doc-izBPj` |
+| Git HEAD SHA | `8aaf68d86abf65764555e7e4d6eb05a4ec55f3f2` |
+| Git status | clean (no uncommitted changes) |
+| Last commit | `8aaf68d` — Khaledaun, 2026-05-04 08:17:38 +0300 — "Merge pull request #781 from Khaledaun/claude/fix-yalla-london-seo-lzFxF" |
+| Production `https://yalla-london.com/` | **HTTP 403 — `x-deny-reason: host_not_allowed`** (21-byte text/plain body, 480ms total) |
+| Production `https://www.yalla-london.com/` | **HTTP 403 — same deny reason** |
+| Production sitemap, robots, /blog | All HTTP 403 (same deny) |
+| Production IP | `216.150.1.193` (NOT Vercel's primary 76.76.21.0/24 range; sister domain `zenithayachts.com` lands at same IP and gives same deny) |
+| Production server header | (empty — no server: header returned) |
+| Cookie / Cloudflare-ray header | absent |
+| Source of `host_not_allowed` string | **NOT in this repo** (`grep -rn "host_not_allowed" .` = zero matches). Confirms the deny is upstream of the Next.js app. |
+| Most-recent on-record health check | `docs/HEALTH-PROBE-RESULTS.md` dated 2026-03-15: **0/19 endpoints PASS, 19 FAIL** (all `timeout after 10000ms`). Production has been at-or-below this state for at least 53 days. |
+| API credentials in this audit shell | Only `ANTHROPIC_BASE_URL` is set. No `GOOGLE_*`, `GSC_*`, `GA4_*`, `DATAFORSEO_*`, `AHREFS_*`, `SEMRUSH_*`, `CLOUDFLARE_*` env vars are present in this session. The repo's `.env.example` documents 121 env-var lines (112 unique names) covering: Database (Supabase + DIRECT_URL + SHADOW), NextAuth, Sentry, GA4 (per-site `GA4_MEASUREMENT_ID_<SITEKEY>`), GSC (per-site `GSC_SITE_URL_<SITEKEY>`), CJ affiliate, Travelpayouts, Stay22, Stripe, Mercury, Resend, WhatsApp, Twitter, Ticketmaster, Unsplash, IndexNow, Cron secret, AI providers (XAI, OpenAI, Claude, Gemini, Perplexity), Cloudflare Workers, Sentry. |
+| Cost cap for this audit | $5.00 |
+| Spend this audit | $0.00 — no paid API calls were possible (production unreachable + zero relevant credentials in shell). |
+
+**Critical note for M3.5 session:** The 403 layer above the app is the highest-priority operator finding. Do not assume any of the live-site behaviour described in this document — every "production" claim has had to be reconstructed from source code. Confirm domain attachment, host allowlist, and any Vercel/Cloudflare proxy configuration before merging M3.5.
+
+---
+
+## Section 1 — URL inventory
+
+### 1.0 — Discovery layer status
+
+| Layer | Source | Status | URLs found |
+|---|---|---|---|
+| 1. `sitemap.xml` (live) | `https://www.yalla-london.com/sitemap.xml` | **HTTP 403** | 0 |
+| 2. `robots.txt` (live) | `https://www.yalla-london.com/robots.txt` | **HTTP 403** | 0 |
+| 3. Recursive crawl | n/a (homepage 403; cannot start crawl) | **Cannot answer — production unreachable** | 0 |
+| 4. Codebase route enumeration | `find app -type f -name 'page.*'` | OK | **191** route files (see 1.1) |
+| 5. GSC top-pages API | n/a (no `GOOGLE_SEARCH_CONSOLE_*` env in this shell) | **Cannot answer — credentials absent** | 0 |
+
+The merged URL set in this document is therefore **codebase-derived only**. URLs that exist on production but not in code (e.g. legacy paths Google still has in its index) are not visible to this audit. The reverse — URLs in code that may not exist on production — is also possible but harder to verify without a live crawl.
+
+### 1.1 — Public-facing routes (codebase-derived; deduplicated)
+
+`Source: find yalla_london/app/app -type f -name "page.tsx" | grep -v /admin/`
+
+| Path pattern | Route file | Notes |
+|---|---|---|
+| `/` | `app/page.tsx` | Homepage. Renders `YallaHomepageEditorial` for site `yalla-london`, `ZenithaHomepage` for yachts, `ZenithaLuxuryHomepage` for parent brand. `force-dynamic`. |
+| `/about` | `app/about/page.tsx` | + layout.tsx. |
+| `/affiliate-disclosure` | `app/affiliate-disclosure/page.tsx` | E-E-A-T trust page. |
+| `/blog` | `app/blog/page.tsx` | Listing. ISR 3600s. `?tag=` query → noindex. |
+| `/blog/[slug]` | `app/blog/[slug]/page.tsx` | Article template (809 lines). ISR 3600s. Falls back to static content from `data/blog-content.ts` + `data/blog-content-extended.ts` if DB lookup fails. |
+| `/blog/category/[slug]` | `app/blog/category/[slug]/page.tsx` | Category listing. |
+| `/brand-guidelines`, `/brand-showcase`, `/design-system` | various | Public access **blocked by middleware** → 302 to `/admin`. Also disallowed in `robots.txt`. Exist only for internal preview. |
+| `/brands` | `app/brands/page.tsx` | Multi-brand portfolio (parent-brand context). |
+| `/charter-planner` | `app/charter-planner/page.tsx` | **Yacht-only.** Renders empty "Coming Soon" on yalla-london. |
+| `/contact` | `app/contact/page.tsx` | + layout.tsx. |
+| `/destinations`, `/destinations/[slug]` | `app/destinations/...` | **Yacht-only.** Excluded from yalla-london sitemap (see code comment in `sitemap.ts:113`). |
+| `/editorial-policy` | `app/editorial-policy/page.tsx` | E-E-A-T trust page. |
+| `/events` | `app/events/page.tsx` | Live Ticketmaster events on homepage; this is the listing page. |
+| `/experiences` | `app/experiences/page.tsx` | Curated activities. |
+| `/faq` | `app/faq/page.tsx` | FAQPage JSON-LD. |
+| `/fleet` | `app/fleet/page.tsx` | **Yacht-only.** |
+| `/glossary` | `app/glossary/page.tsx` | E-E-A-T glossary. |
+| `/guides/london` | `app/guides/london/page.tsx` | London hub guide. |
+| `/halal-charter` | `app/halal-charter/page.tsx` | **Yacht-related**, but lives in yalla-london URL space. Listed in sitemap as priority 0.9. |
+| `/halal-restaurants-london` | `app/halal-restaurants-london/page.tsx` | Pillar landing page (sitemap priority 0.9). |
+| `/hassan1`, `/hassan2` | `app/hassan1/page.tsx`, `app/hassan2/page.tsx` | **Likely test/internal pages** — flagged as "internal traffic" in `lib/analytics/is-internal-traffic.ts` per the layout comment. |
+| `/hotels` | `app/hotels/page.tsx` | Pillar (also receives 301 from `/luxury-hotels-london`). |
+| `/how-it-works` | `app/how-it-works/page.tsx` | **Yacht-only.** |
+| `/information` | `app/information/page.tsx` | Information hub. |
+| `/information/[section]` | `app/information/[section]/page.tsx` | |
+| `/information/articles` | `app/information/articles/page.tsx` | |
+| `/information/articles/[slug]` | `app/information/articles/[slug]/page.tsx` | Information articles (different from `/blog/[slug]`). |
+| `/inquiry`, `/inquiry/confirmation` | `app/inquiry/...` | **Yacht-only.** |
+| `/itineraries`, `/itineraries/[slug]` | `app/itineraries/...` | **Yacht-only.** Excluded from yalla-london sitemap. |
+| `/journal`, `/journal/[slug]` | `app/journal/...` | Editorial journal. |
+| `/london-by-foot`, `/london-by-foot/[slug]` | `app/london-by-foot/...` | Walking-tour content cluster (sitemap priority 0.9). |
+| `/london-with-kids` | `app/london-with-kids/page.tsx` | Pillar (sitemap priority 0.9). |
+| `/luxury-hotels-london` | `app/luxury-hotels-london/page.tsx` | **301-redirected** to `/hotels` by middleware (`PAGE_REDIRECTS`). Excluded from sitemap. The route file still exists for codebase parity. |
+| `/news`, `/news/[slug]` | `app/news/...` | News hub. Daily-updated content. |
+| `/offline` | `app/offline/page.tsx` | Service-worker offline page. Disallowed in robots.txt. |
+| `/privacy`, `/terms` | `app/privacy/page.tsx`, `app/terms/page.tsx` | Legal pages. |
+| `/recommendations` | `app/recommendations/page.tsx` | Pillar (sitemap priority 0.9). |
+| `/shop`, `/shop/[slug]`, `/shop/download`, `/shop/purchases` | `app/shop/...` | E-commerce hub. |
+| `/team`, `/team/[slug]` | `app/team/...` | E-E-A-T author pages. |
+| `/tools/seo-audit` | `app/tools/seo-audit/page.tsx` | Public SEO tool. |
+| `/yachts`, `/yachts/[slug]`, `/yachts/compare` | `app/yachts/...` | **Yacht-only.** |
+| `/api/og` | `app/api/og/route.tsx` | Edge runtime OG image generator. Allowed in robots.txt explicitly. |
+| `/sitemap.xml` | `app/sitemap.ts` | Cache-first MetadataRoute.Sitemap generator. |
+| `/robots.txt` | `app/robots.ts` | Dynamic per-host MetadataRoute.Robots generator. |
+
+**Public route count (excluding `/admin/*`):** ~80 distinct path patterns. Of these, **~17 are yacht-specific** and render a "Coming Soon" or soft-404 state on yalla-london (per the `sitemap.ts` code comment at lines 112–114).
+
+### 1.2 — URL grammar patterns
+
+| Pattern | Example | Concrete examples (codebase) |
+|---|---|---|
+| Root | `/` | `/` (homepage) |
+| Static pillar | `/<page>` | `/about`, `/contact`, `/hotels`, `/experiences`, `/halal-restaurants-london` |
+| Blog | `/blog/<slug>` | `/blog/best-halal-fine-dining-restaurants-london-2025-comparison` |
+| Blog category | `/blog/category/<slug>` | (slugs unknown — DB-driven; static sample doesn't expose categories) |
+| Blog filter | `/blog?category=<slug>` | `/blog?category=food`, `?category=travel`, `?category=culture`, `?category=shopping`, `?category=lifestyle` (linked from footer; tag pages set noindex) |
+| News | `/news/<slug>` | DB-driven, slugs not enumerable from codebase |
+| Information article | `/information/articles/<slug>` | DB-driven |
+| Information section | `/information/<section>` | section names unknown without DB |
+| Walking tour | `/london-by-foot/<slug>` | DB-driven |
+| Journal | `/journal/<slug>` | DB-driven |
+| Team member | `/team/<slug>` | DB-driven |
+| Shop product | `/shop/<slug>` | DB-driven |
+| Arabic mirror | `/ar/<any-EN-path>` | `/ar/blog/<slug>`, `/ar/about`, etc. The `/ar/` prefix is recognised by middleware (`pathname.startsWith("/ar/") || pathname === "/ar"`); rendering is handled by `LanguageProvider initialLocale="ar"`. |
+
+**Important grammar rules** (`Source: middleware.ts + lib/url-utils.ts`):
+- Arabic uses **`/ar/` URL prefix only**. NOT a subdomain, NOT a query parameter, NOT a cookie.
+- Legacy `?lang=ar` query → 301 to `/ar/<path>` (middleware lines 244–249).
+- Legacy `/privacy-policy` → 301 to `/privacy` (middleware `LEGACY_REDIRECTS`).
+- Non-www in production → 301 to `www.` for any host in `DOMAIN_TO_SITE` (middleware lines 282–289).
+- Trailing slash: not enforced (Next.js default `trailingSlash: false`).
+
+### 1.3 — Locale handling
+
+| Mechanism | Where | Behaviour |
+|---|---|---|
+| URL prefix | middleware lines 200–203 | `/ar/...` → `locale=ar`, strip prefix to get effective pathname |
+| Default locale per site | `config/sites.ts` `locale` field | `yalla-london`: `en`. `arabaldives`: `ar`. Yacht sites: `en`. |
+| Hreflang emission | `lib/url-utils.ts → getLocaleAlternates()` | EN-primary site emits `en-GB` + `ar-SA` + `x-default` (EN as default). AR-primary site emits `ar-SA` + `x-default` only (no `en-GB` to avoid 404 promises). Used by every public-page `generateMetadata()`. |
+| Header pass-through | middleware lines 397–414 | Sets `x-site-id`, `x-locale`, `x-hostname`, `x-pathname` for downstream layouts/pages to read via `headers()`. |
+| `<html lang>` | `app/layout.tsx` line 194 | `lang={locale}` and `dir={locale === "ar" ? "rtl" : "ltr"}`. |
+
+### 1.4 — URL-grammar inconsistencies
+
+- **Two parallel article spaces.** `/blog/<slug>` (BlogPost model, primary) and `/information/articles/<slug>` (different model). Internal navigation from header includes both `/blog` and `/information`. The two URL grammars differ by exactly one segment and can confuse Google when topical overlap is high. M3.5 should preserve both URL spaces unless content has been consolidated, but should ensure each article exists in only one space.
+- **Yacht routes on yalla-london.** `/destinations`, `/itineraries`, `/yachts`, `/charter-planner`, `/halal-charter`, `/inquiry`, `/fleet`, `/how-it-works` are all live in the codebase but render empty "Coming Soon" / soft-404 states on yalla-london. The sitemap excludes most of them (per `sitemap.ts:112`), but `/halal-charter` is **listed at priority 0.9** in the yalla-london fallback sitemap. M3.5 should verify whether `/halal-charter` is intentionally yalla-london content or a copy-paste from yacht site.
+- **`/luxury-hotels-london` route still exists** (`app/luxury-hotels-london/page.tsx`) but is permanently 301-redirected by middleware. The route file should be safe to delete after confirming the redirect is hit before any Next.js dynamic route matching. M3.5 should not bring this URL back without evidence that historic backlinks justify reactivation.
+- **`/hassan1`, `/hassan2`** — internal/test pages. They are explicitly listed in `lib/analytics/is-internal-traffic.ts` as paths that block GA4 from loading (per layout.tsx comment at line 281–284). They should not be promoted by M3.5 navigation.
+
+---
+
+## Section 2 — Sitemap + robots
+
+### 2.1 — Sitemap source (verbatim)
+
+**Cannot fetch live sitemap (HTTP 403).** Source code below is from `app/sitemap.ts` (171 lines).
+
+The generator is **cache-first**:
+1. Read `SiteSettings` row keyed by `siteId` (`getCachedSitemap`).
+2. If cache hit, serve instantly (rewriting URLs if hostname mismatches the cached origin).
+3. If cache miss or stale (>24h), trigger background `regenerateSitemapCache(siteId)` (fire-and-forget) and serve a minimal "fallback" sitemap composed of 24 static pillar pages + a fresh DB query for up to 5,000 published `BlogPost` records.
+
+**Static pillar URLs always present in the fallback sitemap** (`Source: app/sitemap.ts lines 91–130`):
+
+```
+/                                priority 1.0   daily
+/blog                            priority 0.9   daily
+/recommendations                 priority 0.9   weekly
+/hotels                          priority 0.8   weekly
+/experiences                     priority 0.8   weekly
+/events                          priority 0.8   weekly
+/news                            priority 0.8   daily
+/halal-restaurants-london        priority 0.9   weekly
+/london-with-kids                priority 0.9   weekly
+/london-by-foot                  priority 0.9   weekly
+/faq                             priority 0.8   monthly
+/glossary                        priority 0.8   monthly
+/halal-charter                   priority 0.9   monthly
+/journal                         priority 0.7   weekly
+/information                     priority 0.7   weekly
+/shop                            priority 0.7   weekly
+/tools                           priority 0.7   monthly
+/tools/seo-audit                 priority 0.7   monthly
+/how-it-works                    priority 0.7   monthly
+/team                            priority 0.6   monthly
+/editorial-policy                priority 0.5   yearly
+/affiliate-disclosure            priority 0.5   yearly
+/about                           priority 0.7   monthly
+/contact                         priority 0.6   monthly
+/privacy                         priority 0.3   yearly
+/terms                           priority 0.3   yearly
+```
+
+**Blog posts** (`Source: app/sitemap.ts lines 149–164`):
+- `prisma.blogPost.findMany({ where: { published: true, deletedAt: null, siteId }, take: 5000 })`
+- Slugs in `BLOG_REDIRECTS` keys are excluded (avoids GSC "Page redirects" warnings).
+- Each entry emits hreflang via `hreflang(/blog/{slug})`.
+
+**Hreflang in fallback** (`Source: app/sitemap.ts lines 80–90`):
+- EN-primary (yalla-london): `{ "en-GB": <url>, "ar-SA": <url with /ar prefix>, "x-default": <en-url> }`.
+- AR-primary (arabaldives): `{ "ar-SA": <url>, "x-default": <ar-url> }` — `en-GB` deliberately omitted.
+
+**Intentional exclusions noted in code comments**:
+- `/luxury-hotels-london` — comment at line 102: redirected to `/hotels`, listing it in sitemap generates "Page redirects" warnings.
+- `/destinations`, `/itineraries` — comment at lines 112–114: yacht-only features.
+
+### 2.2 — Robots source (verbatim)
+
+**Cannot fetch live robots.txt (HTTP 403).** From `app/robots.ts` (120 lines):
+
+| User-agent | Allow | Disallow |
+|---|---|---|
+| `*` | `/`, `/api/og` | `/admin/`, `/api/`, `/_next/`, `/cdn-cgi/`, `/d/`, `/design-system/`, `/brand-showcase/`, `/brand-guidelines/`, `/offline/` |
+| `Googlebot` | `/`, `/api/og` | (same as `*`) |
+| `Google-Extended` | `/` | `` (explicit allow-all — supports Gemini training + AI Overview) |
+| `GPTBot` | `/`, `/api/og` | (same as `*`) |
+| `ChatGPT-User` | `/` | `` |
+| `ClaudeBot`, `anthropic-ai` | `/` | `` |
+| `PerplexityBot` | `/` | `` |
+| `Bingbot` | `/`, `/api/og` | (same as `*`) |
+| `FacebookBot` | `/` | `` |
+| `Applebot` | `/` | `` |
+| `cohere-ai` | `/` | `` |
+
+**Sitemap directive:** `Sitemap: ${baseUrl}/sitemap.xml` where `baseUrl` resolves from middleware-set `x-hostname` → `x-forwarded-host` → `host` → config default.
+
+**Important code comment** (`Source: app/robots.ts lines 14–16`):
+> "Every rule MUST have explicit `disallow` — even if empty string `\"\"`. Next.js omits the Disallow line entirely for empty arrays `[]`, which can cause ambiguous interpretation."
+
+This is a learned-from-bug constraint. M3.5 must keep the convention.
+
+**Disallow rationale comments** (`Source: app/robots.ts lines 32–34`):
+- `/cdn-cgi/` blocks Cloudflare internal endpoints (wastes crawl budget).
+- `/d/` blocks malformed `/d/ownload` URL pattern that Google had previously discovered (broken external link).
+
+### 2.3 — Disallow patterns and implications
+
+- All admin and API routes are blocked from crawling. **Except** `/api/og` is explicitly allowed so Facebook and LinkedIn crawlers can fetch Open Graph images.
+- Internal preview pages (`/design-system`, `/brand-showcase`, `/brand-guidelines`, `/offline`) are blocked from crawling AND blocked from public access by middleware (302 → `/admin`).
+- Eight AI crawlers (GPTBot, ChatGPT-User, ClaudeBot, anthropic-ai, PerplexityBot, FacebookBot, Applebot, cohere-ai, plus Google-Extended) get unrestricted `/` access. This is a deliberate AIO/GEO posture — see CLAUDE.md notes about Google January 2026 Authenticity Update.
+
+### 2.4 — Sitemap diff vs crawled URLs
+
+**Cannot answer — production unreachable.** A diff would compare what the live sitemap emits against what a recursive crawl finds. Both inputs are 403 in this environment. After production is restored, run:
+
+```bash
+curl -fL https://www.yalla-london.com/sitemap.xml > /tmp/sitemap.xml
+# (Then a cheerio/Playwright crawl of the homepage at depth 5, same-origin, capped at 2000 URLs.)
+```
+
+For now, the M3.5 session can use the static pillar list in 2.1 plus the published `BlogPost` count (Section 6) as a planning baseline.
+
+---
+
+## Section 3 — Page-level signals (top 20 URLs)
+
+**Cannot fetch live pages (HTTP 403).** This section reports SEO posture as written in the source, not as observed.
+
+The 20 URLs sampled here are not "top 20 by GSC clicks" (no GSC access) — they are the homepage + 19 routes representative of each grammar pattern in §1.1.
+
+### 3.1 — Posture summary (codebase)
+
+Every public page in this codebase implements `generateMetadata()`. The patterns below come from the root `app/layout.tsx` (defaults) plus per-page overrides.
+
+| Signal | Where it's set | Value |
+|---|---|---|
+| `<title>` | Per-page `generateMetadata()` returning `title:` | Per-route. Root: `${siteName} — ${siteTagline}` (kept under 60 chars; `Source: app/layout.tsx lines 117–118`). |
+| Meta description | Per-page `generateMetadata()` | Per-route. Root: `getSiteDescription(siteId)`. Content quality gate enforces 120–160 chars (per CLAUDE.md). |
+| `<h1>` count | Per-page component | Singletons enforced by SEO standards (`lib/seo/standards.ts`). The root layout does not render an `<h1>`. |
+| Canonical URL | `generateMetadata().alternates.canonical` via `getLocaleAlternates(basePath)` | Locale-aware. EN-primary site canonicalizes EN at root, AR at `/ar/<path>`. |
+| Hreflang annotations | `generateMetadata().alternates.languages` | EN-primary: `en-GB`, `ar-SA`, `x-default`. AR-primary: `ar-SA`, `x-default`. |
+| JSON-LD blocks | `<StructuredData siteId={siteId} />` in root layout + per-page schema generators | Root emits Organization + WebSite. Per-page types observed in `grep '"@type"'`: `Article`, `BlogPosting`, `BreadcrumbList`, `CollectionPage`, `Event`, `FAQPage`, `ItemList`, `LocationFeatureSpecification`, `LodgingBusiness`, `MerchantReturnPolicy`, `MonetaryAmount`, `NewsArticle`, `Offer`, `OfferShippingDetails`, `Organization`, `Person`, `Place`, `Product`, `Trip`, `WebPage`, `WebPageElement`. (See full list at end of `Source: grep '"@type"'` query.) |
+| Open Graph | Per-page `generateMetadata().openGraph` | Type, locale, alternateLocale, url, siteName, title, description, images: `${baseUrl}/api/og?siteId=${siteId}` (1200×630). |
+| Twitter Card | Per-page `generateMetadata().twitter` | `summary_large_image`, `site: @${siteSlug}`, dynamic OG image. |
+| Robots meta | `generateMetadata().robots` | `index: true, follow: true, max-image-preview: large, max-snippet: -1` (root layout). Blog `?tag=` filter pages set `index: false`. |
+| Last-modified header | Vercel default (HTTP `Last-Modified`) | Cannot verify from code alone. |
+| Word count | Content gate | `lib/seo/standards.ts` enforces minimum word counts per content type (blog 500w, news 150w, information 300w, guide 400w) with a target of 1,500–2,000w (per CLAUDE.md April 30 quality reset). |
+
+### 3.2 — Per-URL findings
+
+**Cannot answer — production unreachable.** The 20-URL table the prompt requests requires real Lighthouse / cheerio / Playwright fetches. None are possible against a 403.
+
+What can be reported from code:
+
+| URL | Codebase signal source | Notes from source |
+|---|---|---|
+| `/` | `app/page.tsx` + `app/layout.tsx generateMetadata()` | Title + description + OG + Twitter + canonical + hreflang all set in root layout. Force-dynamic (so headers() works). Renders `YallaHomepageEditorial`. |
+| `/blog` | `app/blog/page.tsx` lines 38–44 | Title `Blog \| ${siteName} — Travel Guides & Tips`. Description targets the configured destination. ISR 3600s. `?tag=` → noindex. |
+| `/blog/[slug]` | `app/blog/[slug]/page.tsx` lines 263–366 | Canonical URL is the EN URL for EN, `/ar/blog/<slug>` for Arabic. Article + BreadcrumbList + ImageObject + Person + Organization + WebPage + WebPageElement JSON-LD generated at lines 507–600+. `canonical_slug` redirect handled at lines 183–195. |
+| `/about`, `/contact`, `/privacy`, `/terms` | individual `layout.tsx` per route | Standard `generateMetadata()` per page. |
+| `/halal-restaurants-london`, `/london-with-kids`, `/london-by-foot` | individual page files | Static-content pillar pages (sitemap priority 0.9). |
+| `/blog/<slug>` (Arabic) | `/ar/blog/<slug>` | Same `app/blog/[slug]/page.tsx` route, locale=ar from middleware, `BlogPostClient` re-renders with Arabic content (and falls back to EN if `content_ar` is empty per CLAUDE.md). |
+| `/api/og?siteId=yalla-london` | `app/api/og/route.tsx` | Edge runtime ImageResponse generator. Per-site brand colors. 1200×630. |
+
+**Recommendation:** when production is reachable, run a Playwright/cheerio sweep against the static pillar list in §2.1 plus the top 10 indexed BlogPost slugs (from GSC) and rebuild this section with real data.
+
+---
+
+## Section 4 — Internal link graph
+
+**Cannot crawl live (production unreachable).** What can be reported from source code:
+
+### 4.1 — Header navigation (universal)
+
+`Source: components/header.tsx lines 17–25`
+
+| Link | Target | Notes |
+|---|---|---|
+| Home | `/` | |
+| Information | `/information` | |
+| Blog | `/blog` | |
+| Recommendations | `/recommendations` | |
+| London by Foot | `/london-by-foot` | |
+| Events & Tickets | `/events` | |
+| About | `/about` | |
+
+7 primary nav links. Plus the logo (links to `/`). The header is a client component (`'use client'`) using `useLanguage()` for translations and `LanguageSwitcher` for `/ar/` toggle. Mobile menu is identical 7 links.
+
+### 4.2 — Footer navigation (universal)
+
+`Source: components/footer.tsx lines 64–169`
+
+**Explore column (5 links):**
+- `/information` — Info Hub
+- `/blog` — London Stories
+- `/events` — Events & Tickets
+- `/london-by-foot` — London by Foot
+- `/recommendations` — Recommendations
+
+**Categories column (5 query-filter links):**
+- `/blog?category=food` — Food & Dining
+- `/blog?category=travel` — Travel & Explore
+- `/blog?category=culture` — Culture & Art
+- `/blog?category=shopping` — Style & Shopping
+- `/blog?category=lifestyle` — Lifestyle
+
+These five `?category=` query-string links route to a tag-filter view that the `/blog` page sets to `noindex` (per `app/blog/page.tsx generateMetadata()`). M3.5 should preserve the noindex on tag pages — the footer link is for users, not crawlers.
+
+**Connect column:**
+- `mailto:info@<site domain>` (computed from `SITES[getDefaultSiteId()].domain`)
+- `/about` — The Founder
+- `/contact` — Contact
+
+**Bottom legal bar:**
+- `/privacy`, `/terms`, `/affiliate-disclosure`, `mailto:${ENTITY.contact.legalEmail}`
+
+### 4.3 — Adjacency summary
+
+**Cannot answer fully — would require a live crawl.** What can be inferred from code:
+
+- **Most-linked-to URLs** (from the universal header + footer alone): `/`, `/blog`, `/information`, `/recommendations`, `/london-by-foot`, `/events`, `/about`, `/contact`. These get one link from every page on the site.
+- **Most-linked-to URLs from blog content (CLAUDE.md April 30 cleanup notes):** the recurring "Best Halal Restaurants" cluster (consolidated into a canonical winner via `BLOG_REDIRECTS`), `/halal-restaurants-london`, `/luxury-hotels-london` (now redirected to `/hotels`), and London-neighborhood guides.
+- **Orphan URL detection:** content-auto-fix Section 11 (per CLAUDE.md) actively detects published articles with zero inbound internal links and appends a "Related:" link from the best-matching article. So orphans are auto-remediated.
+- **Average outbound links per article:** the SEO standards in `lib/seo/standards.ts` require **3+ internal links per blog article** (warning if not met) plus 2+ affiliate/booking links. Static prompt in `config/sites.ts` line 95 enforces the 3+ requirement.
+
+---
+
+## Section 5 — Performance baseline
+
+**Cannot run live Lighthouse against production (HTTP 403).** Lighthouse + chrome-launcher CAN be installed transiently in `/tmp/yalla-london-audit/`, but they need a reachable URL to test.
+
+What can be reported from source code:
+
+### 5.1 — Performance posture (Next.js config)
+
+`Source: yalla_london/app/next.config.js`
+
+| Concern | Setting | Source |
+|---|---|---|
+| Image optimization | **Enabled** (`unoptimized: false`) | next.config.js line 16 |
+| Image formats | `['image/avif', 'image/webp']` | line 17 |
+| Image device sizes | `[640, 750, 828, 1080, 1200, 1920, 2048]` | line 18 |
+| Image cache TTL | 30 days | line 20 |
+| Remote image hosts (allowlisted) | `**.supabase.co/storage`, `**.vercel.app`, `**.cloudflare.com`, `images.unsplash.com`, `plus.unsplash.com`, `images.pexels.com`, all 7 brand domains, `s1.ticketm.net`, `*.ticketmaster.com`, `photo.hotellook.com` (Travelpayouts) | lines 22–95 |
+| Bundle analyzer | `@next/bundle-analyzer` enabled when `ANALYZE=true` | line 3 |
+| Font loading strategy | **Self-hosted via `next/font/google`** (woff2). 5 Yalla fonts (Anybody, Source Serif 4, IBM Plex Mono, Noto Sans Arabic) + 5 Zenitha fonts (Cinzel, Montserrat, Cormorant Garamond, IBM Plex Sans Arabic, JetBrains Mono). All `display: swap`. NO render-blocking Google Fonts CSS. | `app/layout.tsx` lines 38–94 |
+| DNS prefetch / preconnect | `https://www.googletagmanager.com`, `https://www.google-analytics.com`, `https://images.unsplash.com` | `app/layout.tsx` lines 204–212 |
+| ISR (Incremental Static Regeneration) | `revalidate = 3600` on `/blog` listing and `/blog/[slug]` article pages | `app/blog/page.tsx` line 12, `app/blog/[slug]/page.tsx` line 22 |
+| Force-dynamic | Homepage `app/page.tsx` line 21 (`export const dynamic = "force-dynamic"`) | Required because headers() must return real hostname for multi-tenant resolution. |
+| Skip-to-content link | `<a href="#main-content" class="sr-only ...">` | `app/layout.tsx` line 267 |
+| Web Vitals reporter | `<WebVitalsReporter />` in root layout | line 265 |
+| GA4 loader | `<GoogleAnalyticsLoader gaId={...} />` (client component, blocks internal traffic) | line 291. Per-site env via `GA4_MEASUREMENT_ID_<SITEKEY>`. |
+| Service worker / PWA | `<link rel="manifest" href="/manifest.json" />` + theme-color + apple-touch-icon | layout.tsx 215 |
+| Scroll depth tracking | Inline `<script>` at end of `<body>`, requestAnimationFrame-throttled, sends GA4 events at 25/50/75/100% | layout.tsx 296–310 |
+
+### 5.2–5.5 — Lighthouse scores, Core Web Vitals, LCP elements, render-blocking resources
+
+**Cannot answer (5.2 mobile Lighthouse, 5.3 desktop Lighthouse, 5.3 CWV field data, 5.4 LCP elements, 5.5 render-blocking resources)** — all require a reachable production URL.
+
+When production is restored, run:
+
+```bash
+# Mobile
+npx lighthouse --preset=desktop --output=json --output-path=/tmp/lh-desktop.json https://www.yalla-london.com/
+npx lighthouse --output=json --output-path=/tmp/lh-mobile.json https://www.yalla-london.com/
+# CrUX field data via PageSpeed Insights API (requires GOOGLE_PAGESPEED_API_KEY — repo env var name)
+```
+
+The repo's `scripts/seo-audit-playwright.mjs` already has `audit`, `audit-all`, `verify-ssr`, `crawl`, `screenshot` commands; `package.json` exposes them as `seo:audit`, `seo:audit-all`, etc. M3.5 should run `yarn seo:audit-all` after production is reachable.
+
+---
+
+## Section 6 — Content + database
+
+### 6.1 — Article storage
+
+`Source: prisma/schema.prisma lines 104–164`
+
+- **Primary store: Postgres (Supabase) via Prisma.** Model: `BlogPost`. 165 total Prisma models in the schema.
+- **BlogPost field shape (verbatim, abridged):**
+  - `id: String @id @default(cuid())`
+  - `title_en: String`, `title_ar: String` — **bilingual mandatory titles**
+  - `slug: String @unique`
+  - `excerpt_en, excerpt_ar: String?` (optional)
+  - `content_en: String`, `content_ar: String` — **bilingual mandatory content**
+  - `featured_image: String?`
+  - `published: Boolean @default(false)`
+  - `category_id: String`, `author_id: String` — FKs
+  - `meta_title_en, meta_title_ar, meta_description_en, meta_description_ar: String?`
+  - `tags: String[]`
+  - `created_at: DateTime @default(now())`, `updated_at: DateTime @updatedAt`
+  - **Phase 4+ extensions:** `page_type`, `keywords_json`, `questions_json`, `authority_links_json`, `featured_longtails_json`, `seo_score: Int?`, `og_image_id`, `place_id`
+  - **Hardening sprint fields (March 2026):** `source_pipeline String?` ("8-phase" | "legacy-direct" | "manual" | "import"), `trace_id String?`, `enhancement_log Json?` (array of post-publish modifications)
+  - **Photo order (April 2026):** `photo_order_query`, `photo_order_status`
+  - **Duplicate consolidation (April 2026):** `canonical_slug String?` — points to canonical winner; blog page issues 301 redirect to `/blog/{canonical_slug}` so SEO equity is preserved when duplicates are unpublished
+  - **Multi-tenant + soft delete:** `siteId String?`, `deletedAt DateTime?`
+  - Relations: `category`, `author`, `place`
+
+- **CRITICAL note for M3.5** (per CLAUDE.md): `BlogPost` has **NO `title` field** — always use `title_en` / `title_ar`. **NO `quality_score`** — use `seo_score`. **NO `published_at`** — use `created_at` or `updated_at`. Multiple production crashes have been caused by ignoring this.
+
+- **Static fallback content:** `data/blog-content.ts` (1,395 lines, 17 article entries based on slug count; the 12-row count seen in `grep '^  {'` is misleading because the file mixes categories + posts) and `data/blog-content-extended.ts` (5,209 lines, 17 article entries). Total static fallback content ≈ 17–34 articles. These are used **only when DB lookup fails** (per `app/blog/[slug]/page.tsx` lines 9–20).
+
+### 6.2 — Article count by locale
+
+**Cannot answer with a live count — production unreachable, no DATABASE_URL in this shell.** Per CLAUDE.md April 30, 2026: **239 published articles total** (across all locales) — number reported by the operator at the time of the quality reset, with the reset designed to consolidate near-duplicates down to fewer canonical winners. Bilingual articles (EN + AR) are stored on a single BlogPost row (one per article), so 239 is articles, not URL count.
+
+### 6.3 — Image hosting
+
+| Source | Pattern | Use case |
+|---|---|---|
+| Supabase Storage | `**.supabase.co/storage/v1/object/public/**` | User uploads, generated assets |
+| Unsplash CDN | `images.unsplash.com`, `plus.unsplash.com` | Free editorial photography (per CLAUDE.md, free-tier 50 req/hr; UNSPLASH_ACCESS_KEY confirmed set) |
+| Pexels | `images.pexels.com` | Backup photo source |
+| Cloudflare | `**.cloudflare.com` | Optional CDN |
+| Vercel | `**.vercel.app` | Internal preview |
+| Brand domain wildcard | `*.yalla-london.com`, etc. | Self-hosted images |
+| Ticketmaster | `s1.ticketm.net`, `*.ticketmaster.com` | Live event imagery |
+| Travelpayouts/Hotellook | `photo.hotellook.com` | Hotel imagery for affiliate cards |
+
+All hosts are allowlisted in `next.config.js → images.remotePatterns`. The branding directory is checked into the repo: `public/branding/yalla-london/brand-kit/`, `public/branding/yalla-london/brand-kit-v2/`. SVG logos referenced from header (`yalla-primary-light.svg`) and footer (`yalla-stamp-100px.png`).
+
+### 6.4 — Sample of recent articles
+
+**Cannot answer with DB-backed data.** Static fallback slugs (from `data/blog-content.ts`) include:
+
+```
+london-new-years-eve-fireworks-2025-complete-guide
+best-halal-fine-dining-restaurants-london-2025-comparison
+luxury-hotels-london-arab-families-2025-comparison
+best-halal-afternoon-tea-london-2025
+first-time-london-guide-arab-tourists-2025
+harrods-vs-selfridges-which-better-2025
+```
+
+These are the static fallbacks that ship in code; the live DB likely has very different (and more recent) slugs. Note: several of the slugs here include "2025" — per the `systemPromptEN` in `config/sites.ts` line 87, **timeless titles without year suffixes are now mandatory** for new content. The 2025 slugs are legacy.
+
+### 6.5 — Total image asset count
+
+**Cannot answer — would require enumerating Supabase storage + crawl-discovery.** A bounded estimate: each of ~239 published articles has 1 featured image plus 0–6 inline images, suggesting 250–1,700 image assets total.
+
+---
+
+## Section 7 — Tech stack
+
+### 7.1 — Framework + version
+
+- **Next.js `^14.2.32`** (App Router; root layout in `app/layout.tsx`).
+- **App Router only** — no `pages/` directory in the deployed app (`yalla_london/app/`).
+
+### 7.2 — React + TypeScript
+
+- **React `18.2.0`**, `react-dom 18.2.0`.
+- **TypeScript `5.2.2`** (`devDependencies`).
+- **Prisma `6.16.2`** + `@prisma/client ^6.16.2`.
+
+### 7.3 — CSS approach
+
+- **Tailwind CSS `3.3.3`** is the primary system.
+- **CSS-variable design tokens** for both brands. Yalla London tokens in `app/yalla-tokens.css` (yl-red `#C8322B`, yl-gold `#C49A2A`, yl-blue `#4A7BA8`, yl-charcoal `#1C1917`, yl-parchment `#EDE9E1`, yl-cream `#F5F0E8`, yl-navy `#1A2332`, yl-dark-navy `#0F1621`). Zenitha tokens in `app/zenitha-tokens.css` and `app/zenitha-luxury-tokens.css`.
+- Both token files are imported globally in `app/layout.tsx`.
+- **No CSS-in-JS** (no styled-components, emotion, or vanilla-extract).
+- **Hard rule for Arabic:** `app/yalla-tokens.css` line 78 — `[dir="rtl"], .type-ar, [lang="ar"] { letter-spacing: 0 !important; font-family: var(--yl-font-arabic); }`. M3.5 must keep this.
+
+### 7.4 — Component library
+
+- **Radix UI primitives — 28 packages** (`@radix-ui/react-accordion`, `react-alert-dialog`, `react-aspect-ratio`, `react-avatar`, `react-checkbox`, `react-collapsible`, `react-context-menu`, `react-dialog`, `react-dropdown-menu`, `react-hover-card`, `react-label`, `react-menubar`, `react-navigation-menu`, `react-popover`, `react-progress`, `react-radio-group`, `react-scroll-area`, `react-select`, `react-separator`, `react-slider`, `react-slot`, `react-switch`, `react-tabs`, `react-toast`, `react-toggle`, `react-toggle-group`, `react-tooltip`).
+- **Icons:** `lucide-react 0.446.0`.
+- **Animation:** `framer-motion 10.18.0`.
+- **Toast / notifications:** `sonner 1.5.0`.
+- **Theming:** `next-themes 0.3.0`.
+- **State:** `zustand 5.0.3` + `jotai 2.6.0` (mixed usage).
+- **Data fetching:** `swr 2.2.4` + `@tanstack/react-query 5.0.0` (mixed).
+- **Validation:** `zod 3.25`.
+- **Other:** `@headlessui/react 1.7.18`, `date-fns 3.6.0`.
+
+### 7.5 — Font loading
+
+`Source: app/layout.tsx lines 38–94`
+
+**Yalla London (4 fonts — self-hosted via `next/font/google`):**
+- Anybody — `--font-display`
+- Source Serif 4 — `--font-editorial`
+- IBM Plex Mono — `--font-system`
+- Noto Sans Arabic — `--font-arabic`
+
+**Zenitha Yachts / Luxury (5 fonts — self-hosted via `next/font/google`):**
+- Cinzel — `--z-font-display`
+- Montserrat — `--z-font-heading`
+- Cormorant Garamond — `--z-font-body`
+- IBM Plex Sans Arabic — `--z-font-arabic`
+- JetBrains Mono — `--z-font-mono`
+
+All fonts use `display: swap`. Zero render-blocking external Google Fonts CSS.
+
+### 7.6 — Build tool, deployment target
+
+- **Build:** `yarn build` (per `vercel.json`). `package.json` build script runs `bash scripts/deploy-migrations.sh || echo 'Migrations skipped'` then `node scripts/prepare-build.js` then `next build`.
+- **Deploy target:** Vercel (`framework: "nextjs"` in `vercel.json`).
+- **Function maxDuration tiers:**
+  - Default `app/api/**/*.ts` → 30s
+  - `/api/admin/**/*.ts` → 45s
+  - `/api/admin/command-center/**/*.ts` → 60s
+  - `/api/admin/ceo-inbox/**/*.ts` → 300s
+  - `/api/cache/**/*.ts` → 15s
+  - `/api/seo/**/*.ts` → 60s
+  - `/api/health/**/*.ts` → 10s
+  - `/api/cron/**/*.ts` → 300s
+  - `/api/cron/content-cleanup-daily/**/*.ts` → 120s
+  - `/api/affiliate/cron/**/*.ts` → 300s
+  - `/api/database/backups/**/*.ts` → 60s
+- **Cron count:** **54 scheduled crons** in `vercel.json`.
+
+### 7.7 — Package manager + lockfile
+
+- **Yarn** — `yarn.lock` present at `yalla_london/app/yarn.lock`.
+- No `package-lock.json`, no `pnpm-lock.yaml`.
+- `installCommand: yarn install --frozen-lockfile --ignore-engines` (per `vercel.json`).
+
+---
+
+## Section 8 — Integrations + analytics
+
+### 8.1 — Env-var-name inventory (no values)
+
+**121 env-var lines in `.env.example`, 112 unique names**, organised into ~25 sections by `# === ... ===` banners. Notable groups (read full file at `yalla_london/app/.env.example`):
+
+| Service | Notable env-var prefixes |
+|---|---|
+| Database | `DATABASE_URL`, `DIRECT_URL`, `SHADOW_DATABASE_URL` |
+| Supabase | `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY` |
+| NextAuth | `NEXTAUTH_SECRET`, `NEXTAUTH_URL`, `ADMIN_EMAILS` |
+| Sentry | `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE`, `SENTRY_SAMPLE_RATE`, `SENTRY_TRACES_SAMPLE_RATE`, `NEXT_PUBLIC_SENTRY_DSN` |
+| GA4 (per-site) | `GA4_MEASUREMENT_ID_<SITEKEY>`, `NEXT_PUBLIC_GA_MEASUREMENT_ID`, `GA4_API_SECRET`, `GA4_PROPERTY_ID` |
+| GSC (per-site) | `GSC_SITE_URL_<SITEKEY>`, `GOOGLE_SEARCH_CONSOLE_*`, `GOOGLE_ANALYTICS_*`, `GOOGLE_SERVICE_ACCOUNT_KEY`, `GOOGLE_SITE_VERIFICATION_<SITEKEY>` |
+| PageSpeed | `GOOGLE_PAGESPEED_API_KEY` |
+| AI providers | `XAI_API_KEY` (Grok), `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `PERPLEXITY_API_KEY` |
+| Affiliate | `CJ_API_TOKEN`, `CJ_WEBSITE_ID`, `CJ_PUBLISHER_CID`, `TRAVELPAYOUTS_API_TOKEN`, `TRAVELPAYOUTS_MARKER`, `NEXT_PUBLIC_TRAVELPAYOUTS_MARKER`, `NEXT_PUBLIC_STAY22_AID`, `BOOKING_AFFILIATE_ID`, `AGODA_AFFILIATE_ID`, `GETYOURGUIDE_AFFILIATE_ID`, `VIATOR_AFFILIATE_ID` |
+| Indexing | `INDEXNOW_KEY` |
+| Email | `RESEND_API_KEY`, `RESEND_WEBHOOK_SECRET`, `EMAIL_FROM`, `EMAIL_REPLY_TO` |
+| Payments | `STRIPE_*` |
+| Banking | `MERCURY_*` |
+| Social | `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_ACCESS_TOKEN`, `WHATSAPP_VERIFY_TOKEN`, `WHATSAPP_BUSINESS_ACCOUNT_ID`, `TWITTER_API_KEY`, `TWITTER_API_SECRET`, `TWITTER_ACCESS_TOKEN`, `TWITTER_ACCESS_TOKEN_SECRET` |
+| Events | `TICKETMASTER_API_KEY` |
+| Photos | `UNSPLASH_ACCESS_KEY` |
+| Cron | `CRON_SECRET`, `CONTENT_GENERATION_PAUSE` |
+| Bridge | `CLAUDE_BRIDGE_TOKEN` |
+
+**This audit shell has none of these set**, so every "is the integration configured?" question below is from `.env.example` documentation and CLAUDE.md, not live verification.
+
+### 8.2 — Third-party scripts loaded on production pages
+
+**Cannot fetch live HTML.** From source (`components/integrations/monetization-scripts.tsx` and `app/layout.tsx`):
+
+| Script | Strategy | Conditional | Source |
+|---|---|---|---|
+| Google Analytics 4 (gtag) | Client component `GoogleAnalyticsLoader` | Only when GA4 env var resolves AND request is not internal traffic (admin, hassan*, vercel.app preview, internal=true cookie) | `app/layout.tsx` lines 284–292 |
+| Stay22 LetMeAllez | `Script strategy="lazyOnload"` | When `NEXT_PUBLIC_STAY22_AID` is set | `components/integrations/monetization-scripts.tsx` line 29 |
+| Travelpayouts Drive | `Script strategy="afterInteractive"` from `tp-em.com/NTEwNzc2.js?t=510776` | When `NEXT_PUBLIC_TRAVELPAYOUTS_MARKER` is set | line 41+ |
+| Inline scroll-depth tracker | inline `<script dangerouslySetInnerHTML>` | Always (with `typeof gtag !== 'undefined'` guard) | `app/layout.tsx` lines 296–310 |
+
+The `analytics-tracker.tsx` client component additionally registers a click listener on the `document` to detect affiliate-link clicks (looks for `rel="sponsored"`, `/api/affiliate/click` URLs, or known affiliate domains: `booking.com`, `halalbooking.com`, `agoda.com`, `getyourguide.com`, `viator.com`, `klook.com`, `boatbookings.com`, `tripadvisor.com`, `hotels.com`, `expedia.com`). It also detects AI crawlers (GPTBot, ClaudeBot, etc.) on first visit and fires a `ai_crawler_visit` GA4 event.
+
+### 8.3 — Connected SEO tools (audit-time queryability)
+
+| Tool | Connected? | Last successful query (audit-time) | Notes |
+|---|---|---|---|
+| Google Search Console | **No env vars in shell** | Never (this audit) | Repo has GSC integration via `lib/seo/google-search-console.ts` and `mcp-google-server.ts`; CLAUDE.md confirms creds were set in Vercel as of March/April. Not queryable from this shell. |
+| GA4 Data API | **No env vars in shell** | Never | Same — wired in code (`lib/seo/ga4-data-api.ts`), credentials in Vercel only. |
+| DataForSEO | **No env vars in shell** | Never | Repo has client (`lib/chrome-bridge/dataforseo.ts`) per CLAUDE.md April 20 session. Optional. |
+| Ahrefs / Semrush / Moz | **Not integrated** | n/a | No client code in the repo. |
+| Cloudflare Analytics | **No env vars in shell** | Never | Image hosts include `**.cloudflare.com` but no analytics integration code is wired. |
+| Sentry | **No env vars in shell** | Never | Wired into the app via `@sentry/*`. |
+| PageSpeed (PSI API) | **No env vars in shell** | Never | Wired in `lib/performance/site-auditor.ts` per CLAUDE.md. |
+
+### 8.4 — Active redirects
+
+`Source: yalla_london/app/middleware.ts and lib/seo/redirect-map.ts`
+
+| Source | Type | Where | Count |
+|---|---|---|---|
+| `next.config.js redirects()` | Next.js native | (none — `redirects()` not used) | 0 |
+| `vercel.json redirects` | Vercel platform | (none) | 0 |
+| Middleware-based 301s | Custom | middleware.ts | 14 BLOG_REDIRECTS + 1 PAGE_REDIRECT + `/privacy-policy → /privacy` + `?lang=ar → /ar/...` + non-www → www |
+| Middleware-based 302s | Custom | middleware.ts | `/brand-guidelines, /brand-showcase, /design-system → /admin` (3 distinct sources, single target) |
+
+**`BLOG_REDIRECTS`** (`lib/seo/redirect-map.ts`):
+
+```
+# Halal Fine Dining cluster (4 hash-suffix variants → 1 canonical)
+/blog/best-halal-fine-dining-restaurants-london-2025-comparison-79455678  →  /blog/best-halal-fine-dining-restaurants-london-2025-comparison
+/blog/best-halal-fine-dining-restaurants-london-2025-comparison-9088893f  →  /blog/best-halal-fine-dining-restaurants-london-2025-comparison
+/blog/best-halal-fine-dining-restaurants-london-2025-comparison-fasz      →  /blog/best-halal-fine-dining-restaurants-london-2025-comparison
+/blog/best-halal-fine-dining-restaurants-london-2025-comparison-sily      →  /blog/best-halal-fine-dining-restaurants-london-2025-comparison
+
+# Luxury Spas cluster (3 → 1 canonical)
+/blog/best-luxury-spas-london-2026-women-friendly-halal-1xfb              →  /blog/best-luxury-spas-london-2026-women-friendly-halal
+/blog/best-luxury-spas-london-women-friendly-halal                        →  /blog/best-luxury-spas-london-2026-women-friendly-halal
+/blog/luxury-spas-london-arabic                                           →  /blog/best-luxury-spas-london-2026-women-friendly-halal
+
+# London Transport (1 hash-suffix variant)
+/blog/london-transport-guide-tourists-2026-tube-bus-taxi-1pwq             →  /blog/london-transport-guide-tourists-2026-tube-bus-taxi
+
+# Edgware Road (1 hash-suffix variant)
+/blog/edgware-road-london-complete-guide-arab-area-c4f47971               →  /blog/edgware-road-london-complete-guide-arab-area
+
+# Islamic Heritage (date variant)
+/blog/london-islamic-heritage-gems-2026-02-19-0e0828e5                    →  /blog/london-islamic-heritage-gems-2026-02-19-0d2d371b
+
+# Halal Restaurants (date variant)
+/blog/halal-restaurants-london-luxury-2024-guide-2026-02-20               →  /blog/halal-restaurants-london-luxury-2024-guide
+
+# Luxury Hotels cluster (2 → 1 canonical)
+/blog/luxury-hotels-london-arab-families-2025-comparison                  →  /blog/luxury-hotels-london-arab-families
+/blog/muslim-friendly-hotels-london-2026-prayer-facilities-halal          →  /blog/luxury-hotels-london-arab-families
+```
+
+**`PAGE_REDIRECTS`:**
+```
+/luxury-hotels-london  →  /hotels
+```
+
+These redirects are critical SEO state. M3.5 must keep them all functional.
+
+---
+
+## Section 9 — Known issues + operator notes
+
+### 9.1 — Open GitHub issues
+
+**Cannot answer — no `gh` CLI in this audit shell, no GitHub MCP access for repository listing in this read-only mode.** Recent merged PRs (last 30 commits, see 9.5) substitute partially.
+
+### 9.2 — TODO / FIXME / HACK comments in source code
+
+| Marker | Count (excluding node_modules and .next) | Notes |
+|---|---|---|
+| `TODO` | **36** | Concentrated in `components/zenitha-luxury/*` (placeholder content for the parent-brand portfolio site that has not been built out). A handful in CRM (`api/admin/crm/subscribe/route.ts` lines 95, 141 — "TODO: Send confirmation email") and contact form wiring (`components/zenitha-luxury/sections/contact-section.tsx` lines 18, 135 — "TODO: Wire to API endpoint /api/contact"). |
+| `FIXME` | **1** | Location not enumerated in this pass; recommend `grep -rn "FIXME" yalla_london/app --include='*.ts' --include='*.tsx'` if relevant to M3.5 scope. |
+| `HACK` | **0** | Clean. |
+
+**Sample TODOs (top 10):**
+
+```
+components/zenitha-luxury/site-data.ts:6           Items marked with TODO should be replaced with real content
+components/zenitha-luxury/zenitha-luxury-footer.tsx:76    Link to actual policy pages in your app
+components/zenitha-luxury/zenitha-luxury-footer.tsx:114   Replace with real social profiles or remove if not used
+components/zenitha-luxury/sections/contact-section.tsx:18   Wire to API endpoint /api/contact or email service
+components/zenitha-luxury/sections/contact-section.tsx:72   Replace placeholder email and URLs
+components/zenitha-luxury/sections/contact-section.tsx:135  Wire to API endpoint /api/contact or email service
+components/zenitha-luxury/sections/ambassadors-section.tsx:88  Replace static bullets with ambassador profiles
+components/zenitha-luxury/sections/ambassadors-section.tsx:89  Add a world map or location pins
+app/api/admin/crm/subscribe/route.ts:95   Send confirmation email
+app/api/admin/crm/subscribe/route.ts:141  Send double opt-in confirmation email
+```
+
+**For M3.5:** the zenitha-luxury TODOs are out-of-scope for the Yalla London redesign — they apply to a different brand on the same monorepo.
+
+### 9.3 — README + docs/ contents
+
+- **Top-level README.md** (the one in `/home/user/Yalla-london/README.md`, 1,689 bytes) is a brand-pack README for the `/logo/` and `/social-media/` directories. It is not a project README. There is no app-level README at `yalla_london/app/README.md`.
+- **`docs/` directory** contains 35+ Markdown reports. The operator-relevant ones for the M3.5 session:
+  - `docs/PRODUCT-READINESS-REPORT.md` (Feb 2026) — operator-language status: "platform 90% complete, revenue pipeline operational, missing visibility (GA, affiliate clicks, social engagement)".
+  - `docs/HEALTH-PROBE-RESULTS.md` (Mar 15, 2026) — **0/19 endpoints PASS** at probe time; corroborates today's 403 reading.
+  - `docs/AUDIT-LOG.md` — multi-session audit log; recent entries (March 4) document the BlogPost field-name regressions and 21-query multi-site scoping fix.
+  - `docs/FUNCTIONING-ROADMAP.md` — 8-phase roadmap, not yet read in detail in this audit.
+  - `docs/audit/AUDIT_PHASE4C_STATUS.md`, `docs/audit/AUDIT-DASHBOARD-OVERHAUL.md`, `docs/audit/COMMAND_CENTER_TEST_SUITE.md` — internal subsystem audits.
+  - `docs/CTOBRAIN_LOG.md`, `docs/CEOBRAIN_*` — agent-platform planning docs (April 2026).
+
+### 9.4 — package.json scripts named `audit*`, `lint*`, `test*`
+
+Sampled from `yalla_london/app/package.json`:
+
+| Script | Purpose |
+|---|---|
+| `lint` | `next lint` |
+| `typecheck` | `tsc --noEmit` |
+| `test` | `vitest` |
+| `test:watch`, `test:coverage`, `test:smoke`, `test:guards`, `test:security`, `test:migrations`, `test:flags` | Vitest segments |
+| `test:e2e`, `test:integration*` | Playwright |
+| `test:multi-site-isolation` | `npx tsx scripts/multi-site-isolation-test.ts` |
+| `test:load` | k6 (`perf/k6/save-and-list.js`) |
+| `test:canary` | `./scripts/canary.sh` |
+| `test:backup-restore` | `./scripts/backup-restore-drill.sh` |
+| `test:seo:unit`, `test:seo:enhanced` | SEO unit tests |
+| `seo:audit`, `seo:audit-all`, `seo:verify-ssr`, `seo:crawl`, `seo:screenshot` | Playwright-based SEO sweeps (`scripts/seo-audit-playwright.mjs`) |
+| `seo:check` | `npx tsx scripts/seo-check.ts` |
+| `health` | `tsx scripts/health-check.ts` |
+| `health:seo` | `tsx scripts/seo-health.ts` |
+| `validate:pr44`, `validate:deployment`, `validate:automation` | Deployment validators |
+| `analyze` | `ANALYZE=true next build` (bundle analyzer) |
+
+This is a strong test+audit surface. M3.5 should run `seo:audit-all` after production is reachable, and `test:multi-site-isolation` to confirm yalla-london is not contaminated by yacht / luxury-brand state.
+
+### 9.5 — Last 30 commits (operator-visible activity)
+
+Subject lines only (most recent first):
+
+```
+95bda72 fix(observability): capture rejection reasons in CronJobLog.error_message for 3 failing crons
+6d377cb feat(cleanup): topic-discipline gates in weekly-topics
+09ea5c1 feat(cleanup): CONTENT_GENERATION_PAUSE master kill-switch
+016909f feat(cleanup): register clean-slate dry-run in departures board
+b38c8d7 feat(cleanup): /api/admin/clean-slate endpoint — JSON + email + execute
+518e5ef feat(cleanup): clean-slate email renderer (manifest preview + execution result)
+44c22d1 feat(cleanup): clean-slate executor — applies the manifest with re-verification
+4e8c14d feat(cleanup): clean-slate analyzer (read-only manifest builder)
+b13e78d feat(standards): single source of truth — professional content/SEO/AIO/indexing standards
+45e8bd6 feat: Prisma Field Sanity smoke-test category — prevent the wrong-field-name regression class
+34a77d8 fix: yalla-london Grade F → recoverable — sitemap self-heal + threshold realism + batch delegation
+709b8a9 fix(audit-roundup): bump per-fix budget 90s → 180s for content-auto-fix
+80b8b9e fix: ArticleDraft has NO page_type column — stash in research_data instead
+237b9f3 perf: topic diversity + long-tails + page-type intent end-to-end
+1d948ac perf: 3x inbound link injection on orphans + image alt-text auto-fill
+f4127f9 fix: scheduled-publish URL-tracking leak + diagnostic-agent classification gaps
+789f9bf fix: audit-roundup timeout, deep-dive dedup, FTC disclosure auto-injection
+3dafb13 fix(vercel): consolidate functions block under 50-property limit
+c88d0b5 feat(cron): daily content-cleanup at 03:15 UTC to consolidate duplicate slugs
+0de396b fix(resilience): forEachSite respects custom totalTimeoutMs (was always 45s/site)
+88cf8b5 fix(audit-roundup): explicit dimension → cron routing
+06c2c1d fix(briefing): §17 validation map + §16 capture failure reasons
+6ffd108 feat(briefing): dedupe §15 issues + replace §8 inline-block layout with table
+48abe8f fix(daily-briefing): better idempotency key + force-mode override
+85fc31f fix(audit-roundup): production domain + dual auth headers for downstream crons
+d6df59d fix(db-migrate): add DailyBriefing CREATE TABLE + indexes
+2d5e17f fix(briefing): §13 expired = DECLINED only + dead-advertisers detail string
+fbbca03 fix(briefing): correct CjCommission field names + AdvertiserStatus enum + GA4 engagement display
+b06b128 fix(briefing): explicit Set<string> generic on fixType dedup
+1b4a304 fix(briefing): correct field names on getContentCoverage + runLinkHealthAudit
+```
+
+**Operator-cited theme since late April 2026: a "quality reset" against duplicate content clusters.** The clean-slate analyzer/executor is read-only-by-default; it produces a manifest of UNPUBLISH / DELETE / FIX candidates, emails the operator a preview, and only executes when explicitly confirmed. Hard rules: never delete BlogPost rows, never touch articles with traffic or <7 days old. Per CLAUDE.md April 30 session: "PUBLISH FEWER, MUCH BETTER ARTICLES" is the operating principle going forward.
+
+The earlier March commit `34a77d8 — yalla-london Grade F → recoverable` is the most operationally important historical commit. The site was independently audited at Grade F in early March; subsequent fixes (sitemap self-heal, threshold realism, batch delegation) restored it to "recoverable" but the underlying ranking problems (CTR ~0.85% across indexed pages vs target 3.0%, only 22 of 239 articles indexed) remain.
+
+---
+
+## Section 10 — Migration constraints + acceptance hints
+
+### 10.1 — URLs flagged as critical or non-removable in code/docs
+
+| URL pattern | Why it must not change |
+|---|---|
+| `/blog/<slug>` | Article URL grammar — backbone of indexed content. Changing it forces 301s on every published BlogPost row. |
+| `/ar/<any-en-path>` | Arabic locale grammar; explicit middleware rule + GSC `?lang=ar` 301 was added because of indexed legacy URLs. |
+| All 14 `BLOG_REDIRECTS` entries | Each is a hash-suffix or near-duplicate that consolidates to a canonical winner; breaking the redirect re-creates the soft-404 / duplicate-content problem the cluster fix solved. |
+| `/luxury-hotels-london → /hotels` PAGE_REDIRECT | Single static-page consolidation; Google has the redirect cached. |
+| `/privacy-policy → /privacy` | Single LEGACY_REDIRECT in middleware. |
+| `/sitemap.xml`, `/robots.txt` | Both are dynamic Next.js routes that read `x-hostname` from middleware. Must keep middleware setting these headers on EXCLUDED_PATHS. |
+| `/api/og` | Open Graph image generator. Must keep it explicitly allowed in `robots.txt`. |
+| IndexNow key file `/{INDEXNOW_KEY}.txt` | Vercel rewrite + middleware bypass at `app/api/indexnow-key/route.ts`. Must keep all three layers. |
+| `/api/affiliate/click` | Server-side affiliate click tracker; receives `_ga` cookie passthrough. |
+| `/api/gdpr/delete` | Public GDPR right-to-erasure endpoint. Must remain public + functional. |
+
+### 10.2 — Custom redirects already configured
+
+(See Section 8.4 — full list of 16 active redirects.)
+
+### 10.3 — High-traffic URLs
+
+**Cannot answer with GSC clicks data — no access in this shell.** From codebase priority signals (sitemap fallback priorities + footer/header link counts):
+
+| URL | Sitemap priority | Inbound links from header/footer |
+|---|---|---|
+| `/` | 1.0 | universal logo + Home nav |
+| `/blog` | 0.9 | universal nav + footer Explore |
+| `/halal-restaurants-london` | 0.9 | sitemap pillar |
+| `/london-with-kids` | 0.9 | sitemap pillar |
+| `/london-by-foot` | 0.9 | universal nav + footer Explore |
+| `/recommendations` | 0.9 | universal nav + footer Explore |
+| `/halal-charter` | 0.9 | sitemap pillar (verify intent — yacht-flavoured) |
+| `/hotels` | 0.8 | sitemap pillar (also receives 301 traffic from `/luxury-hotels-london`) |
+| `/experiences` | 0.8 | sitemap pillar |
+| `/events` | 0.8 | universal nav + footer Explore |
+| `/news` | 0.8 | sitemap pillar |
+| `/faq` | 0.8 | sitemap pillar (FAQPage JSON-LD candidate) |
+| `/glossary` | 0.8 | sitemap pillar (E-E-A-T) |
+| `/information` | 0.7 | universal nav + footer Explore |
+
+When production is reachable, replace this with a real GSC top-100-by-clicks query.
+
+### 10.4 — Hreflang inconsistencies
+
+**Cannot answer fully — no live observation.** From code review:
+
+- The `getLocaleAlternates()` helper (`lib/url-utils.ts`) emits hreflang correctly for both EN-primary and AR-primary sites.
+- The cache-first sitemap mirrors the same logic in `buildFallbackSitemap`'s `hreflang(path)` helper.
+- **One known constraint:** AR-primary sites (`arabaldives`) deliberately omit `en-GB` because there is no `/en/*` route — listing `en-GB` would 404. This is correct. M3.5 must not "fix" the omission.
+- **One historical issue (per CLAUDE.md):** GSC reported "Duplicate — alternate page with canonical" warnings before `getLocaleAlternates()` was made locale-aware. The fix is in place; M3.5 must keep it.
+
+### 10.5 — JSON-LD coverage gaps
+
+**Cannot enumerate from production.** From source: every public-facing route has at minimum the root `<StructuredData siteId={siteId} />` injecting Organization + WebSite. Per-page schema is generated for Article, BreadcrumbList, etc. No specific gaps surfaced from code grep.
+
+### 10.6 — Image alt text coverage
+
+**Cannot answer — would need to crawl rendered HTML for `<img alt>` and `<Image alt>` audit.** From CLAUDE.md: alt-text auto-fill is a recurring fix area (March 2026 commit `1d948ac perf: 3x inbound link injection on orphans + image alt-text auto-fill`). M3.5 should re-audit alt coverage after production access.
+
+### 10.7 — Mobile-readability spot-check
+
+**Cannot perform — production unreachable.** This is the section the prompt notes "are likely operator complaints." Without a live mobile load, M3.5 should:
+1. Run `npx playwright test --headed --device='iPhone 13'` on the homepage + blog post + halal-restaurants pillar after production is reachable.
+2. Look for: horizontal overflow, text size below 14px, touch targets below 44×44, illegible Arabic in `dir="rtl"`, header overlap on iPhone notch / Dynamic Island viewports.
+3. The codebase has explicit `viewport-fit=cover` (`app/layout.tsx` line 216) and `pb-16 lg:pb-0` body padding (mobile bottom-nav clearance). Verify both behave on real iPhones.
+
+---
+
+## Section 11 — Recommendations for M3.5 redesign
+
+These are non-visual operational findings. Visual design is locked in the Zenitha brand pack and the existing token system (`yalla-tokens.css`).
+
+### 11.1 — URL grammar M3.5 must preserve verbatim
+
+| Pattern | M3.5 rule |
+|---|---|
+| `/blog/<slug>` | Keep exactly. Do not introduce `/post/<slug>`, `/articles/<slug>`, or any other variant. |
+| `/ar/<any-EN-path>` | Keep `/ar/` prefix exactly. Do not move to subdomain or query. |
+| 24 static pillar paths | Keep all as-is (they are the sitemap fallback contract; see §2.1). |
+| 14 `BLOG_REDIRECTS` | Every entry must keep its 301 target as a published BlogPost. Breaking any of these reintroduces the duplicate-content problem the consolidation solved. |
+| 1 `PAGE_REDIRECTS` | `/luxury-hotels-london → /hotels` must keep working. |
+| `/sitemap.xml`, `/robots.txt`, `/api/og`, IndexNow key file | All four are SEO-critical and have specific middleware/Vercel-rewrite behavior. Don't touch unless explicitly redoing the SEO surface. |
+
+### 11.2 — URLs that are safe to retire
+
+| URL | Rationale |
+|---|---|
+| `/hassan1`, `/hassan2` | Internal/test pages flagged in `lib/analytics/is-internal-traffic.ts` as paths that block GA4 from loading. They have no public navigation and no sitemap presence. Safe to remove unless they are referenced by a specific external link. |
+| `/luxury-hotels-london` route file | The 301 target works; the route file still exists for parity. Safe to delete the file as long as middleware redirect order ensures the redirect fires before route matching. |
+| `/brand-guidelines`, `/brand-showcase`, `/design-system` | Already 302-blocked from public. Route files can stay for internal use. Sitemap and robots already exclude them. Nothing to do unless M3.5 wants to remove the codebase paths. |
+
+### 11.3 — Pages where SEO signals are missing in production — M3.5 should improve, not just preserve
+
+**Cannot validate from production.** Likely-improvement candidates based on code review and CLAUDE.md notes:
+
+- **`/team/<slug>`** pages — E-E-A-T author profiles. Per CLAUDE.md, E-E-A-T is the #1 ranking signal post January 2026 Authenticity Update. M3.5 should ensure each team-member page has full Person JSON-LD + bio + social links + author-attribution backlinks from blog posts.
+- **`/halal-charter`** — listed in sitemap as priority 0.9 but appears to be yacht-flavoured content. Verify whether it belongs on yalla-london at all; if yes, ensure the page actually serves halal-charter content and not a "Coming Soon" yacht stub.
+- **`/journal/<slug>`, `/london-by-foot/<slug>`, `/information/articles/<slug>`** — three parallel article spaces. Confirm that each space has distinct intent and is not topically overlapping with `/blog/<slug>`. If overlap exists, consolidate to a single canonical space (avoid the "two `/post/*` spaces" anti-pattern).
+- **OG images on /blog/<slug>** — every page emits `${baseUrl}/api/og?siteId=...` as the default OG. Verify whether per-article images (from the `og_image_id` BlogPost field) supersede the default; if not, M3.5 should wire in per-article OG.
+
+### 11.4 — Performance bottlenecks the redesign should address
+
+**Cannot measure from production.** From code review:
+
+- **Force-dynamic homepage** (`app/page.tsx` line 21). This is necessary for multi-tenant resolution but means the homepage cannot benefit from full static generation. M3.5 could move to Partial Prerendering (Next 14.2.x supports it) once stable, to keep the dynamic header read while pre-rendering the rest.
+- **Blog `[slug]` ISR at 3600s** is reasonable. M3.5 should keep this.
+- **Sitemap cache-first design** is excellent. M3.5 must NOT break it (the `SiteSettings` cache row + the 4-hourly `content-auto-fix-lite` cron refresh are the contract).
+- **Two state libraries** (zustand + jotai) and **two data libraries** (swr + react-query) are present. M3.5 might consider consolidating, but only if a single domain is being touched; cross-cutting consolidation is out of scope for a redesign.
+- **191 routes in App Router** is a lot for a 6-site monorepo. ~110 of them are admin. Production users only ever see ~80 public routes; admin is server-rendered behind auth. No specific perf concern, just a navigation surface to keep mental track of.
+
+### 11.5 — Internal-link patterns the redesign must preserve
+
+- **Header (7 links): Home, Information, Blog, Recommendations, London by Foot, Events, About.** Universal — every page links to all 7. Removing any one will deindex it from the universal-link signal.
+- **Footer Explore (5 links): Information, Blog, Events, London by Foot, Recommendations.** Universal.
+- **Footer Categories (5 query-filtered links to /blog?category=...).** These are user-facing only; the destination `/blog` page sets `noindex` for tag pages — keep this exact pattern.
+- **Footer Connect (mailto + About + Contact).** Universal.
+- **Footer Legal (Privacy, Terms, Affiliates, mailto Legal).** Universal.
+- **Within-article internal links: 3 minimum per blog post**, enforced as a warning-level pre-publication check (per `lib/seo/standards.ts`). M3.5 must not change this rule downward.
+
+### 11.6 — Content fields the M3.5 BlogPost schema must accommodate
+
+The BlogPost schema (Section 6.1) is rich and will not need changes for a frontend redesign. M3.5 should NOT touch the schema. Specifically, M3.5 must read:
+
+- `title_en`, `title_ar`, `slug`, `content_en`, `content_ar`, `meta_title_*`, `meta_description_*`
+- `featured_image` (URL string)
+- `tags` (string array)
+- `keywords_json`, `questions_json` (Phase 4+ extensions, may or may not be present)
+- `seo_score` (NOT `quality_score` — wrong field name has caused production crashes 4 times)
+- `created_at`, `updated_at` (NOT `published_at` — also a 4-time regression)
+- `canonical_slug` — if non-null, the article 301-redirects to `/blog/<canonical_slug>`. M3.5 frontend must handle this transparently (the existing route already does).
+- `enhancement_log` — JSON array of post-publish modifications. M3.5 doesn't need to render this but should not strip it on update.
+- `author_id` → TeamMember relation — for E-E-A-T author bylines.
+
+If M3.5 needs new fields, add them as nullable extensions, not as required columns (existing 239 articles must not be invalidated).
+
+---
+
+## Appendix A — Audit shell limitations
+
+This audit ran in a sandboxed Linux shell with:
+- No production access (HTTP 403 from the host's upstream layer)
+- No `GOOGLE_*`, `GSC_*`, `GA4_*`, `DATAFORSEO_*`, `AHREFS_*`, `SEMRUSH_*`, `CLOUDFLARE_*` env vars
+- No `gh` CLI available
+- No Lighthouse / chrome-launcher pre-installed (transient install was possible but not useful without a reachable URL)
+- No live database access (no `DATABASE_URL` in this shell)
+
+For a follow-up pass with full data — when production is reachable and credentials are loaded — the eight "Cannot answer" items in this document should resolve.
+
+## Appendix B — Eight "Cannot answer" items, by section
+
+1. **§1.0 layer 1** — live sitemap.xml content.
+2. **§1.0 layer 2** — live robots.txt content.
+3. **§1.0 layer 3** — recursive crawl discovery.
+4. **§1.0 layer 5** — GSC top-pages-by-clicks.
+5. **§3.2** — per-URL live signals (titles, metas, canonicals, JSON-LD as rendered, OG, Twitter, robots header, Last-Modified).
+6. **§5.2 / 5.3 / 5.4 / 5.5** — Lighthouse mobile + desktop, CWV field data, LCP elements, render-blocking resources.
+7. **§6.2** — exact published-article counts by locale and **§6.4** — sample of 3 most-recent articles.
+8. **§10.7** — mobile-readability spot-check (the operator-feedback gathering item).
+
+## Appendix C — Pre-flight before M3.5 starts coding
+
+1. Resolve the `host_not_allowed` 403. Steps to investigate (in order):
+   - In Vercel dashboard: confirm `yalla-london.com` and `www.yalla-london.com` are attached to the project that deploys this repo.
+   - Confirm DNS A/CNAME records still point at Vercel's edge (`216.150.1.193` is a Vercel IP per recent prefix expansion, but verify against Vercel's published list).
+   - Check Vercel project's "Domains" tab for any "domain misconfigured" or "needs verification" warnings.
+   - Check whether a Cloudflare or other proxy is in front; the `x-deny-reason: host_not_allowed` header is consistent with a Vercel platform-level domain-not-attached deny.
+   - If the domain was attached to a separate Vercel project for the M3.5 staging build, point production back to the main project.
+2. Confirm with operator that `CONTENT_GENERATION_PAUSE` is not set (or that they are OK with pipelines paused during the M3.5 cutover).
+3. Run `yarn typecheck` (= `tsc --noEmit`) and `yarn test:smoke` after pulling the M3.5 branch — both should be green before merge.
+4. Run `yarn seo:audit-all` once production is reachable and diff against this document's recommendations.
+5. Do not modify `lib/seo/redirect-map.ts`, `app/sitemap.ts`, `app/robots.ts`, or middleware redirect blocks except to extend them.
+
+---
+
+*End of M3.5 handoff audit document.*


### PR DESCRIPTION
Read-only audit producing a single comprehensive document (docs/audit/m3.5-handoff.md, ~943 lines, 12 sections) covering:

- Production unreachable (HTTP 403 host_not_allowed at upstream layer)
- URL inventory from codebase (191 routes; ~80 public)
- Sitemap + robots verbatim (cache-first design preserved)
- Page-level SEO posture (codebase-only; live fetch not possible)
- Internal link graph from header/footer/content rules
- Performance posture (next.config + font self-hosting + ISR)
- Content store (BlogPost schema, ~239 articles per CLAUDE.md)
- Tech stack (Next 14.2.32 / React 18.2 / TS 5.2 / Prisma 6.16)
- Integrations + analytics inventory (.env.example: 121 vars)
- Recent operator activity (clean-slate, topic-discipline gates)
- Migration constraints (14 BLOG_REDIRECTS + 1 PAGE_REDIRECT)
- Recommendations for M3.5 (URL grammar, SEO signals, perf)

Eight items marked "Cannot answer" because they require live production access (currently 403) and/or GSC credentials (absent from this audit shell).

The document is consumable as ground truth for the downstream M3.5 redesign session.

https://claude.ai/code/session_015H9x8YSoFpqFCHfWBNVj14