### PR TITLE
fix: pipeline upstream + UI hardening from May 17 audit

### DIFF
--- a/.claude/logs/sessions/2026-05-17_15-47.md
+++ b/.claude/logs/sessions/2026-05-17_15-47.md
@@ -1,0 +1,9 @@
+# Session Log: 2026-05-17_15-47
+- **Session ID:** 091c0c4f-8f5a-4e85-8675-16fc81c37564
+- **Branch:** claude/review-pr-fix-plan-qdFlQ
+- **Uncommitted changes:** 0
+
+## Changes
+```
+
+```

--- a/.claude/logs/sessions/2026-05-17_15-52.md
+++ b/.claude/logs/sessions/2026-05-17_15-52.md
@@ -1,0 +1,10 @@
+# Session Log: 2026-05-17_15-52
+- **Session ID:** 57a97f3c-5378-49b1-b5a1-ef1ad6cbd139
+- **Branch:** claude/review-pr-fix-plan-qdFlQ
+- **Uncommitted changes:** 2
+
+## Changes
+```
+ PROJECT_STATUS.md | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+```

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 > Auto-updated by Claude Code session hooks
 
 ## Last Session
-- Date: 2026-05-17 14:32 UTC
+- Date: 2026-05-17 15:52 UTC
 - Branch: (auto-filled on session stop)
 - Summary: Initial automation setup
 - Files changed: 2 files

--- a/yalla_london/app/app/api/cron/content-auto-fix-lite/route.ts
+++ b/yalla_london/app/app/api/cron/content-auto-fix-lite/route.ts
@@ -76,6 +76,9 @@ async function handleAutoFixLite(request: NextRequest) {
     titleArtifactsCleaned: 0,
     duplicatesUnpublished: 0,
     imageAltsFixed: 0,
+    // May 17 2026 re-audit additions
+    titlesResanitized: 0,
+    duplicateEventsUnpublished: 0,
     errors: [] as string[],
   };
 
@@ -1038,6 +1041,157 @@ async function handleAutoFixLite(request: NextRequest) {
     } catch (e) {
       results.errors.push(`image-alt-autofill: ${e instanceof Error ? e.message : String(e)}`);
       console.warn("[content-auto-fix-lite] Section 17 failed:", e instanceof Error ? e.message : e);
+    }
+  }
+
+  // ── Section 18: Re-run title sanitization with new patterns ──────────
+  // May 17 2026 re-audit added trailing-comma/semicolon, V2/V3 versioning,
+  // and bracket-placeholder detection to sanitizeTitle. Older posts may have
+  // titles like "Marathon Guide 2025: Training," or "Best Tea V2: Ultimate"
+  // that pre-date the sanitizer changes — re-run on candidates that match
+  // these patterns. 24h cooldown so we don't fight fresh AI runs.
+  if (Date.now() - cronStart < BUDGET_MS - 8_000) {
+    try {
+      const { sanitizeTitle, sanitizeMetaDescription } = await import(
+        "@/lib/content-pipeline/title-sanitizer"
+      );
+      const TITLE_CAP = 50;
+      const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+      const candidates = await prisma.blogPost.findMany({
+        where: {
+          siteId: { in: activeSiteIds },
+          updated_at: { lt: cutoff },
+          OR: [
+            { title_en: { endsWith: "," } },
+            { title_en: { endsWith: ";" } },
+            { title_en: { contains: " V2" } },
+            { title_en: { contains: " V3" } },
+            { title_en: { contains: " v2" } },
+            { title_en: { contains: " v3" } },
+            { title_en: { contains: "[" } },
+            { title_ar: { endsWith: "،" } },
+            { title_ar: { contains: " V2" } },
+            { title_ar: { contains: "[" } },
+          ],
+        },
+        select: {
+          id: true,
+          slug: true,
+          title_en: true,
+          title_ar: true,
+          meta_title_en: true,
+          meta_title_ar: true,
+          meta_description_en: true,
+          meta_description_ar: true,
+        },
+        orderBy: { updated_at: "asc" },
+        take: TITLE_CAP,
+      });
+
+      let titlesResanitized = 0;
+      for (const post of candidates) {
+        if (Date.now() - cronStart > BUDGET_MS - 3_000) break;
+
+        const newTitleEn = sanitizeTitle(post.title_en || "");
+        const newTitleAr = sanitizeTitle(post.title_ar || "");
+        const newMetaTitleEn = sanitizeTitle(post.meta_title_en || "");
+        const newMetaTitleAr = sanitizeTitle(post.meta_title_ar || "");
+        const newMetaDescEn = sanitizeMetaDescription(post.meta_description_en || "");
+        const newMetaDescAr = sanitizeMetaDescription(post.meta_description_ar || "");
+
+        const noChange =
+          newTitleEn === (post.title_en || "") &&
+          newTitleAr === (post.title_ar || "") &&
+          newMetaTitleEn === (post.meta_title_en || "") &&
+          newMetaTitleAr === (post.meta_title_ar || "") &&
+          newMetaDescEn === (post.meta_description_en || "") &&
+          newMetaDescAr === (post.meta_description_ar || "");
+        if (noChange) continue;
+
+        try {
+          await optimisticBlogPostUpdate(
+            post.id,
+            (current) => {
+              const updates: Record<string, unknown> = {};
+              const ten = sanitizeTitle((current.title_en as string) || "");
+              const tar = sanitizeTitle((current.title_ar as string) || "");
+              const mten = sanitizeTitle((current.meta_title_en as string) || "");
+              const mtar = sanitizeTitle((current.meta_title_ar as string) || "");
+              const mden = sanitizeMetaDescription((current.meta_description_en as string) || "");
+              const mdar = sanitizeMetaDescription((current.meta_description_ar as string) || "");
+              if (ten !== (current.title_en || "")) updates.title_en = ten;
+              if (tar !== (current.title_ar || "")) updates.title_ar = tar;
+              if (mten !== (current.meta_title_en || "")) updates.meta_title_en = mten;
+              if (mtar !== (current.meta_title_ar || "")) updates.meta_title_ar = mtar;
+              if (mden !== (current.meta_description_en || "")) updates.meta_description_en = mden;
+              if (mdar !== (current.meta_description_ar || "")) updates.meta_description_ar = mdar;
+              if (Object.keys(updates).length === 0) return null;
+              return updates;
+            },
+            { tag: "[content-auto-fix-lite:section-18]" },
+          );
+          titlesResanitized++;
+          console.log(`[content-auto-fix-lite:s18] ${post.slug}: re-sanitized title/meta`);
+        } catch (err) {
+          console.warn(
+            `[content-auto-fix-lite:s18] ${post.slug} update failed:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }
+      results.titlesResanitized = titlesResanitized;
+      if (titlesResanitized > 0) {
+        console.log(`[content-auto-fix-lite:s18] Re-sanitized ${titlesResanitized} title(s)/meta(s)`);
+      }
+    } catch (e) {
+      results.errors.push(`title-resanitization: ${e instanceof Error ? e.message : e}`);
+      console.warn("[content-auto-fix-lite:s18] Section 18 failed:", e instanceof Error ? e.message : e);
+    }
+  }
+
+  // ── Section 19: Duplicate event de-dup ────────────────────────────────
+  // May 17 re-audit: "Twist Museum" appeared 7× in 11 /events listings. Same
+  // physical event re-listed per category by upstream Ticketmaster IDs. Dedup
+  // by (title_en, venue, date) — unpublish duplicates (keep oldest).
+  if (Date.now() - cronStart < BUDGET_MS - 5_000) {
+    try {
+      const allEvents = await prisma.event.findMany({
+        where: { siteId: { in: activeSiteIds }, published: true, date: { gte: new Date() } },
+        select: { id: true, title_en: true, venue: true, date: true, created_at: true },
+        orderBy: { created_at: "asc" },
+        take: 500,
+      });
+
+      const seen = new Map<string, string>();
+      const dupes: string[] = [];
+      for (const ev of allEvents) {
+        const titleKey = (ev.title_en || "").trim().toLowerCase();
+        const venueKey = (ev.venue || "").trim().toLowerCase();
+        const dateKey = ev.date.toISOString().slice(0, 10);
+        const key = `${titleKey}|${venueKey}|${dateKey}`;
+        if (seen.has(key)) {
+          dupes.push(ev.id);
+        } else {
+          seen.set(key, ev.id);
+        }
+      }
+
+      let duplicateEventsUnpublished = 0;
+      if (dupes.length > 0) {
+        const toUnpublish = dupes.slice(0, 30); // cap per run
+        const updateResult = await prisma.event.updateMany({
+          where: { id: { in: toUnpublish } },
+          data: { published: false },
+        });
+        duplicateEventsUnpublished = updateResult.count;
+        console.log(
+          `[content-auto-fix-lite:s19] Unpublished ${duplicateEventsUnpublished} duplicate event(s)`,
+        );
+      }
+      results.duplicateEventsUnpublished = duplicateEventsUnpublished;
+    } catch (e) {
+      results.errors.push(`event-dedup: ${e instanceof Error ? e.message : e}`);
+      console.warn("[content-auto-fix-lite:s19] Section 19 failed:", e instanceof Error ? e.message : e);
     }
   }
 

--- a/yalla_london/app/app/api/cron/content-auto-fix/route.ts
+++ b/yalla_london/app/app/api/cron/content-auto-fix/route.ts
@@ -2179,6 +2179,7 @@ Constraints:
         console.warn("[content-auto-fix] Section 26 skipped: not the registered owner of affiliate_links");
       } else {
         // Tracking-param keys we recognize. Empty value = broken attribution.
+        // May 17 re-audit additions: clickref (CJ), sub_id (Awin/Travelpayouts).
         const TRACKING_KEYS = [
           "ref",
           "partner_id",
@@ -2189,6 +2190,8 @@ Constraints:
           "aff",
           "affid",
           "subid",
+          "sub_id",
+          "clickref",
           "utm_source",
           "marker",
         ];
@@ -2259,10 +2262,13 @@ Constraints:
           // don't accidentally strip editorial links to BBC/Time Out/etc.
           const PARTNER_HOSTS = new RegExp(
             // Affiliate partner domains where empty tracking = leakage
+            // May 17 re-audit: added halalbooking (direct link no tracking),
+            // universe.com + eticketing.co.uk (sponsored rel only, no aff ID).
             "(booking\\.com|expedia\\.com|hotels\\.com|agoda\\.com|getyourguide\\.com|" +
               "viator\\.com|thefork\\.|opentable\\.|tripadvisor\\.|stubhub\\.|" +
               "blacklane\\.com|welcomepickups\\.com|tiqets\\.com|ticketnetwork\\.com|" +
-              "klook\\.com|skyscanner\\.|sportsevents365\\.com)",
+              "klook\\.com|skyscanner\\.|sportsevents365\\.com|halalbooking\\.com|" +
+              "universe\\.com|eticketing\\.co\\.uk)",
             "i",
           );
           const DIRECT_LINK_RE = /<a\b[^>]*\bhref="(https?:\/\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/gi;
@@ -2300,6 +2306,9 @@ Constraints:
               { content_en: { contains: "expedia.com" } },
               { content_en: { contains: "getyourguide.com" } },
               { content_en: { contains: "tripadvisor." } },
+              { content_en: { contains: "halalbooking.com" } },
+              { content_en: { contains: "universe.com" } },
+              { content_en: { contains: "eticketing.co.uk" } },
             ],
           },
           select: { id: true, slug: true, content_en: true, content_ar: true },
@@ -2366,6 +2375,289 @@ Constraints:
       const msg = err instanceof Error ? err.message : String(err);
       results.errors.push(`empty-param-affiliate-strip: ${msg}`);
       console.warn("[content-auto-fix:s26] Section 26 failed:", msg);
+    }
+  }
+
+  // ── Section 27: Raw pipe-table backfill (May 17 2026 re-audit) ────────────
+  // Some older published articles ship pipe-table syntax raw: "| col | col |"
+  // sequences inside <p> tags that never got converted to <table> by the assembly
+  // phase. BlogPostClient now also unwraps them at render, but DB cleanup means
+  // canonical content is always semantic HTML — better for AI search ingestion,
+  // schema.org extraction, and copy-to-clipboard UX.
+  if (Date.now() - cronStart < BUDGET_MS - 15_000) {
+    try {
+      const { convertPipeTables, hasPipeTable, unwrapPipeParagraphs } = await import(
+        "@/lib/markdown/pipe-tables"
+      );
+      const PIPE_CAP = 20;
+      const candidates = await prisma.blogPost.findMany({
+        where: {
+          siteId: { in: activeSiteIds },
+          published: true,
+          deletedAt: null,
+          // Pre-filter: look for table separator rows (|---| or | --- |)
+          OR: [
+            { content_en: { contains: "|---" } },
+            { content_en: { contains: "| ---" } },
+            { content_ar: { contains: "|---" } },
+            { content_ar: { contains: "| ---" } },
+          ],
+        },
+        select: { id: true, slug: true, content_en: true, content_ar: true },
+        orderBy: { updated_at: "asc" },
+        take: PIPE_CAP,
+      });
+
+      let pipeFixed = 0;
+      for (const post of candidates) {
+        if (Date.now() - cronStart > BUDGET_MS - 5_000) break;
+
+        const enUnwrapped = unwrapPipeParagraphs(post.content_en || "");
+        const arUnwrapped = unwrapPipeParagraphs(post.content_ar || "");
+        const needEn = hasPipeTable(enUnwrapped);
+        const needAr = hasPipeTable(arUnwrapped);
+        if (!needEn && !needAr) continue;
+
+        try {
+          await optimisticBlogPostUpdate(
+            post.id,
+            (current) => {
+              const curEn = unwrapPipeParagraphs((current.content_en as string) || "");
+              const curAr = unwrapPipeParagraphs((current.content_ar as string) || "");
+              const fixEn = hasPipeTable(curEn);
+              const fixAr = hasPipeTable(curAr);
+              if (!fixEn && !fixAr) return null;
+              const updates: Record<string, unknown> = {};
+              if (fixEn) updates.content_en = convertPipeTables(curEn);
+              if (fixAr) updates.content_ar = convertPipeTables(curAr);
+              updates.enhancement_log = buildEnhancementLogEntry(
+                current.enhancement_log,
+                "markdown_tables",
+                "content-auto-fix",
+                `Converted ${(fixEn ? 1 : 0) + (fixAr ? 1 : 0)} raw pipe-table block(s) to <table>`,
+              );
+              return updates;
+            },
+            { tag: "[content-auto-fix:section-27]" },
+          );
+          pipeFixed++;
+          console.log(`[content-auto-fix:s27] ${post.slug}: pipe table → <table>`);
+        } catch (err) {
+          console.warn(
+            `[content-auto-fix:s27] ${post.slug} update failed:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }
+
+      (results as Record<string, unknown>).pipeTablesConverted = pipeFixed;
+      if (pipeFixed > 0) {
+        console.log(`[content-auto-fix:s27] Converted pipe tables in ${pipeFixed} article(s)`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      results.errors.push(`pipe-tables-backfill: ${msg}`);
+      console.warn("[content-auto-fix:s27] Section 27 failed:", msg);
+    }
+  }
+
+  // ── Section 28: Bracket placeholder body cleanup ──────────────────────────
+  // May 17 re-audit: "high hotel prices with [x] unexpected add-on costs" leaked
+  // to AR hero. Title-level placeholders are blocked by pre-pub gate Check 17,
+  // but body-level placeholders only warn (auto-fix sweeps them post-hoc).
+  // sanitizeContentBody now strips BRACKET_PLACEHOLDER as well — re-run on existing rows.
+  if (Date.now() - cronStart < BUDGET_MS - 10_000) {
+    try {
+      const { sanitizeContentBody } = await import("@/lib/content-pipeline/title-sanitizer");
+      const PLACEHOLDER_CAP = 30;
+      const candidates = await prisma.blogPost.findMany({
+        where: {
+          siteId: { in: activeSiteIds },
+          published: true,
+          deletedAt: null,
+          OR: [
+            { content_en: { contains: "[x]" } },
+            { content_ar: { contains: "[x]" } },
+            { content_en: { contains: "[TBD]" } },
+            { content_ar: { contains: "[TBD]" } },
+            { content_en: { contains: "[insert" } },
+            { content_en: { contains: "[placeholder" } },
+            { content_en: { contains: "[TODO]" } },
+          ],
+        },
+        select: { id: true, slug: true, content_en: true, content_ar: true },
+        orderBy: { updated_at: "asc" },
+        take: PLACEHOLDER_CAP,
+      });
+
+      let placeholdersStripped = 0;
+      for (const post of candidates) {
+        if (Date.now() - cronStart > BUDGET_MS - 3_000) break;
+
+        try {
+          await optimisticBlogPostUpdate(
+            post.id,
+            (current) => {
+              const curEn = (current.content_en as string) || "";
+              const curAr = (current.content_ar as string) || "";
+              const newEn = sanitizeContentBody(curEn);
+              const newAr = sanitizeContentBody(curAr);
+              if (newEn === curEn && newAr === curAr) return null;
+              const updates: Record<string, unknown> = {};
+              if (newEn !== curEn) updates.content_en = newEn;
+              if (newAr !== curAr) updates.content_ar = newAr;
+              updates.enhancement_log = buildEnhancementLogEntry(
+                current.enhancement_log,
+                "bracket_placeholders",
+                "content-auto-fix",
+                "Stripped unfilled bracket placeholder(s) from article body",
+              );
+              return updates;
+            },
+            { tag: "[content-auto-fix:section-28]" },
+          );
+          placeholdersStripped++;
+          console.log(`[content-auto-fix:s28] ${post.slug}: stripped bracket placeholders`);
+        } catch (err) {
+          console.warn(
+            `[content-auto-fix:s28] ${post.slug} update failed:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }
+
+      (results as Record<string, unknown>).bracketPlaceholdersStripped = placeholdersStripped;
+      if (placeholdersStripped > 0) {
+        console.log(
+          `[content-auto-fix:s28] Stripped placeholders from ${placeholdersStripped} article(s)`,
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      results.errors.push(`bracket-placeholder-cleanup: ${msg}`);
+      console.warn("[content-auto-fix:s28] Section 28 failed:", msg);
+    }
+  }
+
+  // ── Section 29: Mojibake repair (BlogPost + Event) ────────────────────────
+  // May 17 re-audit: "Willie Colã³N" on /events. UTF-8 double-encoding from
+  // upstream ingestion (Ticketmaster, news feeds). repairMojibake() is safe-by-
+  // default — only rewrites when decode produces valid Latin/Arabic AND removes
+  // the mojibake markers. If validation fails, the original string is preserved.
+  if (Date.now() - cronStart < BUDGET_MS - 8_000) {
+    try {
+      const { repairRecord } = await import("@/lib/utils/mojibake");
+      const MOJI_BLOG_CAP = 30;
+      const MOJI_EVENT_CAP = 30;
+      let blogRepaired = 0;
+      let eventRepaired = 0;
+
+      // BlogPost title fields (content body is usually safe — mojibake mostly appears in
+      // shorter fields that pass through ingest scripts without normalization).
+      const blogCandidates = await prisma.blogPost.findMany({
+        where: {
+          siteId: { in: activeSiteIds },
+          OR: [
+            { title_en: { contains: "Ã" } },
+            { title_ar: { contains: "Ã" } },
+            { title_en: { contains: "â€" } },
+          ],
+        },
+        select: { id: true, slug: true, title_en: true, title_ar: true },
+        orderBy: { updated_at: "asc" },
+        take: MOJI_BLOG_CAP,
+      });
+
+      for (const post of blogCandidates) {
+        if (Date.now() - cronStart > BUDGET_MS - 5_000) break;
+        const diff = repairRecord(post, ["title_en", "title_ar"]);
+        if (!diff) continue;
+        try {
+          await optimisticBlogPostUpdate(
+            post.id,
+            (current) => {
+              const updates = repairRecord(
+                {
+                  title_en: (current.title_en as string) || null,
+                  title_ar: (current.title_ar as string) || null,
+                },
+                ["title_en", "title_ar"],
+              );
+              if (!updates) return null;
+              return {
+                ...updates,
+                enhancement_log: buildEnhancementLogEntry(
+                  current.enhancement_log,
+                  "mojibake_repair",
+                  "content-auto-fix",
+                  "Repaired UTF-8 double-encoded characters in title",
+                ),
+              };
+            },
+            { tag: "[content-auto-fix:section-29]" },
+          );
+          blogRepaired++;
+          console.log(`[content-auto-fix:s29] ${post.slug}: mojibake repaired in title`);
+        } catch (err) {
+          console.warn(
+            `[content-auto-fix:s29] ${post.slug} update failed:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }
+
+      // Event records (title + venue + descriptions)
+      if (Date.now() - cronStart < BUDGET_MS - 3_000) {
+        const eventCandidates = await prisma.event.findMany({
+          where: {
+            siteId: { in: activeSiteIds },
+            OR: [
+              { title_en: { contains: "Ã" } },
+              { title_ar: { contains: "Ã" } },
+              { venue: { contains: "Ã" } },
+              { title_en: { contains: "â€" } },
+              { venue: { contains: "â€" } },
+            ],
+          },
+          select: { id: true, title_en: true, title_ar: true, venue: true, description_en: true, description_ar: true },
+          take: MOJI_EVENT_CAP,
+        });
+
+        for (const ev of eventCandidates) {
+          if (Date.now() - cronStart > BUDGET_MS - 2_000) break;
+          const diff = repairRecord(ev as Record<string, string | null | undefined>, [
+            "title_en",
+            "title_ar",
+            "venue",
+            "description_en",
+            "description_ar",
+          ]);
+          if (!diff) continue;
+          try {
+            await prisma.event.update({
+              where: { id: ev.id },
+              data: diff as Record<string, string>,
+            });
+            eventRepaired++;
+          } catch (err) {
+            console.warn(
+              `[content-auto-fix:s29] event ${ev.id} update failed:`,
+              err instanceof Error ? err.message : err,
+            );
+          }
+        }
+      }
+
+      (results as Record<string, unknown>).mojibakeRepaired = blogRepaired + eventRepaired;
+      if (blogRepaired + eventRepaired > 0) {
+        console.log(
+          `[content-auto-fix:s29] Repaired ${blogRepaired} blog + ${eventRepaired} event mojibake records`,
+        );
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      results.errors.push(`mojibake-repair: ${msg}`);
+      console.warn("[content-auto-fix:s29] Section 29 failed:", msg);
     }
   }
 

--- a/yalla_london/app/app/api/cron/events-sync/route.ts
+++ b/yalla_london/app/app/api/cron/events-sync/route.ts
@@ -43,14 +43,34 @@ export async function GET(request: NextRequest) {
       if (tmEvents.length > 0) {
         const { prisma } = await import("@/lib/db");
 
+        // May 17 2026 re-audit: normalize incoming text BEFORE insert to prevent
+        // mojibake ("Willie Colã³N") and trim whitespace. Also dedup by composite
+        // (title+venue+date) — Ticketmaster sometimes emits the same physical event
+        // under different IDs per category, causing the "Twist Museum 7×" bug.
+        const { repairMojibake } = await import("@/lib/utils/mojibake");
+        const normalize = (s: string | null | undefined): string =>
+          repairMojibake(s || "").normalize("NFC").trim();
+
         for (const tm of tmEvents.slice(0, 15)) {
           if (Date.now() - startTime > BUDGET_MS) break;
 
           try {
-            // Check if we already have this Ticketmaster event
-            const existing = await prisma.event.findFirst({
+            const cleanName = normalize(tm.name);
+            const cleanVenue = normalize(tm.venue);
+            const cleanCity = normalize(tm.city);
+            const eventDate = new Date(tm.date + "T00:00:00Z");
+
+            // Check 1: existing by Ticketmaster ID
+            let existing = await prisma.event.findFirst({
               where: { affiliateTag: `tm-${tm.id}`, siteId },
             });
+
+            // Check 2: existing by composite (title+venue+date) — catches duplicate IDs
+            if (!existing) {
+              existing = await prisma.event.findFirst({
+                where: { siteId, title_en: cleanName, venue: cleanVenue, date: eventDate },
+              });
+            }
 
             if (existing) {
               // Update price/image if changed
@@ -71,13 +91,13 @@ export async function GET(request: NextRequest) {
 
             await prisma.event.create({
               data: {
-                title_en: tm.name,
-                title_ar: tm.name, // TODO: AI translate
-                description_en: `${tm.name} at ${tm.venue}, ${tm.city}. ${tm.category} event.`,
-                description_ar: `${tm.name} في ${tm.venue}. فعالية ${tm.category}.`,
-                date: new Date(tm.date + "T00:00:00Z"),
+                title_en: cleanName,
+                title_ar: cleanName, // TODO: AI translate
+                description_en: `${cleanName} at ${cleanVenue}, ${cleanCity}. ${tm.category} event.`,
+                description_ar: `${cleanName} في ${cleanVenue}. فعالية ${tm.category}.`,
+                date: eventDate,
                 time: tm.time || "19:00",
-                venue: tm.venue,
+                venue: cleanVenue,
                 category: mapCategory(tm.segment || tm.category),
                 price: formatEventPrice(tm),
                 image: tm.imageUrl || null,

--- a/yalla_london/app/app/api/events/route.ts
+++ b/yalla_london/app/app/api/events/route.ts
@@ -47,11 +47,21 @@ export async function GET(request: NextRequest) {
         ];
       }
 
-      dbEvents = await prisma.event.findMany({
+      // May 17 2026 re-audit: dedup by (title_en, venue, date) — Ticketmaster
+      // sometimes emits the same physical event under multiple category IDs,
+      // causing "Twist Museum" to appear 7× in 11 listings. Take 200 rows to
+      // leave headroom for dedup, then slice to 50 after.
+      const rawEvents = await prisma.event.findMany({
         where,
         orderBy: { date: "asc" },
-        take: 50,
+        take: 200,
       });
+      const seenKeys = new Map<string, (typeof rawEvents)[number]>();
+      for (const e of rawEvents) {
+        const key = `${(e.title_en ?? "").trim().toLowerCase()}|${(e.venue ?? "").trim().toLowerCase()}|${e.date.toISOString().slice(0, 10)}`;
+        if (!seenKeys.has(key)) seenKeys.set(key, e);
+      }
+      dbEvents = Array.from(seenKeys.values()).slice(0, 50);
     } catch (dbErr) {
       console.warn(
         "[events] DB query failed, falling back to Ticketmaster:",

--- a/yalla_london/app/app/blog/[slug]/BlogPostClient.tsx
+++ b/yalla_london/app/app/blog/[slug]/BlogPostClient.tsx
@@ -24,6 +24,7 @@ import { FollowUs } from "@/components/follow-us";
 import { Stay22Map } from "@/components/integrations/stay22-map";
 import { WeatherWidget } from "@/components/integrations/weather-widget";
 import AffiliateDisclosure from "@/components/affiliate/AffiliateDisclosure";
+import { convertPipeTables, unwrapPipeParagraphs } from "@/lib/markdown/pipe-tables";
 
 interface AuthorData {
   name_en: string;
@@ -152,47 +153,8 @@ export default function BlogPostClient({ post, serverLocale, unsplashAttribution
       : post.content_en
     : "";
 
-  // Convert GFM-style pipe tables (| col | col | with |---|---| separator)
-  // into HTML <table>. Walks lines, identifies contiguous table blocks, and
-  // emits semantic <thead>/<tbody>. Plays well with mixed markdown+HTML
-  // documents: lines outside table blocks are returned unchanged.
-  const convertPipeTables = (input: string): string => {
-    const lines = input.split(/\r?\n/);
-    const isRow = (s: string) => /^\s*\|.*\|\s*$/.test(s) && s.includes("|", s.indexOf("|") + 1);
-    const isSep = (s: string) => /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/.test(s);
-    const cellsFrom = (s: string) =>
-      s
-        .replace(/^\s*\|/, "")
-        .replace(/\|\s*$/, "")
-        .split("|")
-        .map((c) => c.trim());
-
-    const out: string[] = [];
-    let i = 0;
-    while (i < lines.length) {
-      const header = lines[i];
-      const sep = lines[i + 1] || "";
-      if (isRow(header) && isSep(sep)) {
-        const headerCells = cellsFrom(header);
-        const rows: string[][] = [];
-        let j = i + 2;
-        while (j < lines.length && isRow(lines[j])) {
-          rows.push(cellsFrom(lines[j]));
-          j++;
-        }
-        const thead = `<thead><tr>${headerCells.map((c) => `<th>${c}</th>`).join("")}</tr></thead>`;
-        const tbody = rows.length
-          ? `<tbody>${rows.map((r) => `<tr>${r.map((c) => `<td>${c}</td>`).join("")}</tr>`).join("")}</tbody>`
-          : "";
-        out.push(`<table class="md-table">${thead}${tbody}</table>`);
-        i = j;
-      } else {
-        out.push(header);
-        i++;
-      }
-    }
-    return out.join("\n");
-  };
+  // convertPipeTables + unwrapPipeParagraphs imported from @/lib/markdown/pipe-tables
+  // (shared with assembly phase so pipe tables are converted at write time too).
 
   // Safety net: convert markdown syntax to HTML if content was stored as
   // markdown instead of HTML (some older or failed pipeline runs). This
@@ -267,7 +229,11 @@ export default function BlogPostClient({ post, serverLocale, unsplashAttribution
     });
   };
 
-  const rawContentMd = markdownToHtml(rawContentPreH1);
+  // Unconditional pipe-table conversion BEFORE markdownToHtml, including <p>-wrapped
+  // pipe rows (May 17 re-audit found tables shipped as <p>| Col | Col |</p> which
+  // markdownToHtml stage-2 would skip because the HTML detector sees structural tags).
+  const rawContentTablesFixed = convertPipeTables(unwrapPipeParagraphs(rawContentPreH1));
+  const rawContentMd = markdownToHtml(rawContentTablesFixed);
   const rawContent = transformRestaurantFacts(
     rawContentMd
       .replace(/<h1(\s[^>]*)?>|<h1>/gi, "<h2$1>")

--- a/yalla_london/app/app/hotels/hotels-content.tsx
+++ b/yalla_london/app/app/hotels/hotels-content.tsx
@@ -593,6 +593,30 @@ export default function HotelsPage({ serverLocale }: { serverLocale?: "en" | "ar
       });
   }, []);
 
+  // Curated luxury London hotel placeholder photos from Unsplash (legal hotlink,
+  // free, no attribution required for editorial display — see unsplash ToS).
+  // Per May 17 2026 audit: Hotellook URLs returned 0×0 on several hotels; gradient
+  // placeholders converted poorly. These are deterministic per hotel slug so each
+  // card gets a stable, visually-appropriate fallback while real photos are
+  // backfilled by the image-pipeline cron.
+  const UNSPLASH_FALLBACK_PHOTOS = [
+    "https://images.unsplash.com/photo-1551882547-ff40c63fe5fa?w=800&q=80", // luxury hotel lobby
+    "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb?w=800&q=80", // hotel exterior dusk
+    "https://images.unsplash.com/photo-1564501049412-61c2a3083791?w=800&q=80", // luxury hotel room
+    "https://images.unsplash.com/photo-1566073771259-6a8506099945?w=800&q=80", // grand hotel facade
+    "https://images.unsplash.com/photo-1582719508461-905c673771fd?w=800&q=80", // luxury room w view
+    "https://images.unsplash.com/photo-1455587734955-081b22074882?w=800&q=80", // boutique hotel
+  ];
+
+  // Deterministic photo by hotel name hash — same hotel always gets same photo.
+  const getFallbackPhoto = (hotelName: string): string => {
+    let hash = 0;
+    for (let i = 0; i < hotelName.length; i++) {
+      hash = (hash * 31 + hotelName.charCodeAt(i)) & 0xfffffff;
+    }
+    return UNSPLASH_FALLBACK_PHOTOS[hash % UNSPLASH_FALLBACK_PHOTOS.length];
+  };
+
   const handlePhotoError = (hotelName: string) => {
     setFailedPhotos((prev) => {
       if (prev.has(hotelName)) return prev;
@@ -750,38 +774,60 @@ export default function HotelsPage({ serverLocale }: { serverLocale?: "en" | "ar
           {filteredHotels.map((hotel) => (
             <BrandCardLight key={hotel.id} className="overflow-hidden group">
               <div className="relative h-56">
-                {realPhotos[hotel.name] && !failedPhotos.has(hotel.name) ? (
-                  <Image
-                    src={realPhotos[hotel.name]}
-                    alt={hotel.name}
-                    fill
-                    sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                    className="object-cover group-hover:scale-105 transition-transform duration-500 ease-yl"
-                    onError={() => handlePhotoError(hotel.name)}
-                    unoptimized
-                  />
-                ) : (
-                  // No verified property photo — render a branded gradient placeholder
-                  // instead of a generic/wrong stock photo. Real photos are fetched
-                  // client-side via /api/integrations/hotel-photos; this shows while
-                  // we wait OR permanently for hotels without licensed photos.
-                  <div
-                    className="absolute inset-0 flex flex-col items-center justify-center p-6 text-center"
-                    style={{
-                      background: "linear-gradient(135deg, #0f1621 0%, #1a2234 40%, #C49A2A 100%)",
-                    }}
-                  >
-                    <span className="font-mono text-[10px] text-white/50 uppercase tracking-[0.2em] mb-2">
-                      {hotel.badge}
-                    </span>
-                    <h4 className={`text-white font-heading font-bold text-lg ${isRTL ? "font-arabic" : ""}`}>
-                      {hotel.name}
-                    </h4>
-                    <p className="font-mono text-[9px] text-white/40 uppercase tracking-[0.15em] mt-3">
-                      {hotel.location}
-                    </p>
-                  </div>
-                )}
+                {/* Gradient placeholder as deepest layer — visible only if the image
+                    above fails to load (Unsplash CDN block, very rare). Branded text
+                    keeps the card scannable even in that worst-case scenario. */}
+                <div
+                  className="absolute inset-0 flex flex-col items-center justify-center p-6 text-center"
+                  style={{
+                    background: "linear-gradient(135deg, #0f1621 0%, #1a2234 40%, #C49A2A 100%)",
+                  }}
+                >
+                  <span className="font-mono text-[10px] text-white/50 uppercase tracking-[0.2em] mb-2">
+                    {hotel.badge}
+                  </span>
+                  <h4 className={`text-white font-heading font-bold text-lg ${isRTL ? "font-arabic" : ""}`}>
+                    {hotel.name}
+                  </h4>
+                  <p className="font-mono text-[9px] text-white/40 uppercase tracking-[0.15em] mt-3">
+                    {hotel.location}
+                  </p>
+                </div>
+
+                {/* Photo overlay: real property photo when available (Hotellook via
+                    /api/integrations/hotel-photos), Unsplash curated fallback when
+                    not. May 17 2026 audit: card gradients converted poorly at £650+
+                    nightly rates — replaced with deterministic Unsplash photos so
+                    every card shows a luxury-hotel visual.
+                    onError on Image hides itself so the gradient below shows through. */}
+                <Image
+                  src={
+                    realPhotos[hotel.name] && !failedPhotos.has(hotel.name)
+                      ? realPhotos[hotel.name]
+                      : getFallbackPhoto(hotel.name)
+                  }
+                  alt={
+                    realPhotos[hotel.name] && !failedPhotos.has(hotel.name)
+                      ? hotel.name
+                      : `${hotel.name} (representative photo)`
+                  }
+                  fill
+                  sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                  className="object-cover group-hover:scale-105 transition-transform duration-500 ease-yl"
+                  onError={(e) => {
+                    handlePhotoError(hotel.name);
+                    (e.currentTarget as HTMLImageElement).style.display = "none";
+                  }}
+                  onLoad={(e) => {
+                    // Detect 0×0 broken-but-200 responses (Hotellook server-side block).
+                    const img = e.currentTarget as HTMLImageElement;
+                    if (img.naturalWidth === 0 || img.naturalHeight === 0) {
+                      handlePhotoError(hotel.name);
+                      img.style.display = "none";
+                    }
+                  }}
+                  unoptimized
+                />
                 <span className={`absolute top-3 ${isRTL ? "right-3" : "left-3"}`}>
                   <BrandTag color="blue">{hotel.badge}</BrandTag>
                 </span>

--- a/yalla_london/app/components/home/yalla-homepage.tsx
+++ b/yalla_london/app/components/home/yalla-homepage.tsx
@@ -810,8 +810,20 @@ export function YallaHomepage({ locale = "en" }: YallaHomepageProps) {
 
   // Build article list: DB articles first, then fallback
   // Filter to only show articles with content in the current locale
+  // May 17 2026 re-audit: AR homepage was showing English titles because the AR filter
+  // only checked truthiness \u2014 articles with title_ar holding English content passed
+  // through. Strict filter rejects English contamination and bracket placeholder leaks.
+  const isArabicTitleEligible = (titleAr: string | null | undefined): boolean => {
+    if (!titleAr || titleAr.trim().length < 10) return false;
+    if (/\[[a-zA-Z_]{1,20}\]/.test(titleAr)) return false; // bracket placeholder leak
+    const stripped = titleAr.replace(/\s/g, "");
+    if (stripped.length === 0) return false;
+    const arabicChars = (stripped.match(/[\u0600-\u06FF]/g) || []).length;
+    return arabicChars / stripped.length >= 0.6;
+  };
+
   const localeArticles = dbArticles.filter((a) => {
-    if (locale === "ar") return a.title_ar && a.title_ar.length > 5;
+    if (locale === "ar") return isArabicTitleEligible(a.title_ar);
     return a.title_en && a.title_en.length > 5 && !/^[\u0600-\u06FF]/.test(a.title_en); // Exclude Arabic-only titles from EN page
   });
   const articles =
@@ -820,25 +832,34 @@ export function YallaHomepage({ locale = "en" }: YallaHomepageProps) {
           id: a.id || String(i),
           slug: a.slug || "#",
           category: a.category?.name || (locale === "ar" ? "مقال" : "Article"),
-          title: (locale === "ar" ? a.title_ar : a.title_en) || a.title_en || "",
-          excerpt: (locale === "ar" ? a.meta_description_ar : a.meta_description_en) || a.meta_description_en || "",
+          // AR locale: NO fallback to title_en — strict filter above already gated.
+          title: locale === "ar" ? (a.title_ar || "") : (a.title_en || a.title_ar || ""),
+          excerpt: locale === "ar"
+            ? (a.meta_description_ar || "")
+            : (a.meta_description_en || a.meta_description_ar || ""),
           image: `https://images.unsplash.com/photo-1513635269975-59663e0ac1ad?w=600&q=80`,
           date: formatRelativeDate(a.created_at, locale),
           readTime: locale === "ar" ? "5 دقائق" : "5 min read",
         }))
       : fallbackArticles[locale];
 
-  // Use first DB article as featured if available
+  // Use first eligible DB article as featured (must pass locale filter).
+  // For AR: featured must have proper Arabic title — no English leak in hero card.
+  const featuredCandidate = dbArticles.find((a) =>
+    locale === "ar" ? isArabicTitleEligible(a.title_ar) : !!a.title_en,
+  );
   const effectiveFeatured =
-    dbArticles.length > 0
+    featuredCandidate
       ? {
           ...featured,
-          slug: dbArticles[0].slug || featured.slug,
-          title: (locale === "ar" ? dbArticles[0].title_ar : dbArticles[0].title_en) || featured.title,
+          slug: featuredCandidate.slug || featured.slug,
+          title: locale === "ar"
+            ? (featuredCandidate.title_ar || featured.title)
+            : (featuredCandidate.title_en || featured.title),
           excerpt:
-            (locale === "ar" ? dbArticles[0].meta_description_ar : dbArticles[0].meta_description_en) ||
+            (locale === "ar" ? featuredCandidate.meta_description_ar : featuredCandidate.meta_description_en) ||
             featured.excerpt,
-          date: formatRelativeDate(dbArticles[0].created_at, locale),
+          date: formatRelativeDate(featuredCandidate.created_at, locale),
         }
       : featured;
 

--- a/yalla_london/app/lib/affiliate/partner-detector.ts
+++ b/yalla_london/app/lib/affiliate/partner-detector.ts
@@ -33,6 +33,11 @@ export function detectPartner(url: string): string {
   if (lower.includes("ticketnetwork.com")) return "ticketnetwork";
   if (lower.includes("stay22.com")) return "stay22";
   if (lower.includes("tp.media") || lower.includes("travelpayouts.com")) return "travelpayouts";
+  // May 17 re-audit — register for attribution even before commission signup.
+  // Click-tracker can record referrals via GA/Plausible until partnership is live.
+  if (lower.includes("universe.com")) return "universe";
+  if (lower.includes("eticketing.co.uk")) return "eticketing";
+  if (lower.includes("ticketmaster.co.uk") || lower.includes("ticketmaster.com")) return "ticketmaster";
   return "cj-other";
 }
 

--- a/yalla_london/app/lib/campaigns/article-enhancer.ts
+++ b/yalla_london/app/lib/campaigns/article-enhancer.ts
@@ -200,10 +200,11 @@ RULES:
 5. BANNED PHRASES: "in conclusion", "look no further", "whether you're a X or a Y", "in this comprehensive guide", "nestled in the heart of", "without further ado", "it's worth noting".
 5. AFFILIATE LINKS: Use <a href="https://www.booking.com/searchresults.html?ss=${encodeURIComponent(keyword)}" target="_blank" rel="nofollow sponsored" class="affiliate-link">Book on Booking.com</a> or similar.
 6. NO markdown. HTML only. No preamble.
+7. HYGIENE: NEVER use bracket placeholders ([x], [TBD], [insert ...]) — fill or omit. NEVER use versioning suffixes (V2, V3, v2). NEVER end titles with trailing comma, semicolon, colon, or pipe.
 
 At the end, on separate lines:
-META_TITLE: [50-60 chars, keyword near front]
-META_DESCRIPTION: [120-155 chars, compelling with keyword]`;
+META_TITLE: [50-60 chars, keyword near front. No bracket placeholders, no V2/V3, no trailing punctuation]
+META_DESCRIPTION: [120-155 chars, compelling with keyword. No bracket placeholders]`;
 
     return { prompt, mode: 'patch' };
   }
@@ -237,10 +238,11 @@ RULES:
 7. INTERNAL LINKS: Use exactly the href format from the AVAILABLE INTERNAL LINKS list with class="internal-link".
 8. Keep the same tone and writing style as the original article.
 9. NO markdown. Return only HTML.
+10. HYGIENE: NEVER use bracket placeholders ([x], [TBD], [insert ...]) — fill or omit. NEVER use versioning suffixes (V2, V3, v2). NEVER end titles with trailing comma, semicolon, colon, or pipe.
 
 At the end, on separate lines return:
-META_TITLE: [50-60 chars, keyword near front]
-META_DESCRIPTION: [120-155 chars, compelling with keyword]
+META_TITLE: [50-60 chars, keyword near front. No bracket placeholders, no V2/V3, no trailing punctuation]
+META_DESCRIPTION: [120-155 chars, compelling with keyword. No bracket placeholders]
 
 Return ONLY the enhanced HTML followed by META_TITLE and META_DESCRIPTION lines. No preamble, no explanation.`;
 

--- a/yalla_london/app/lib/content-engine/scripter.ts
+++ b/yalla_london/app/lib/content-engine/scripter.ts
@@ -16,6 +16,20 @@ import { getSiteConfig, getSiteDomain, getDefaultSiteId } from '@/config/sites';
 
 const TAG = '[content-engine:scripter]';
 
+// Template hygiene rules appended to every AI system prompt in this module.
+// Mirrors getTemplateHygieneDirectives() in lib/content-pipeline/phases.ts.
+// Catches: bracket placeholders ([x], [TBD]), versioning slugs (V2, V3),
+// trailing punctuation in titles, English contamination in Arabic content.
+const HYGIENE_RULES = `
+
+TITLE & CONTENT HYGIENE — STRICT, NO EXCEPTIONS:
+- NEVER use bracket placeholders like [x], [TBD], [TODO], [insert ...], [topic], [destination], [keyword]. Fill with real values or omit.
+- NEVER append versioning suffixes like "V2", "V3", "v2", "Version 2". These are internal-only.
+- NEVER end titles with trailing comma, semicolon, colon, pipe, or dash.`;
+
+const HYGIENE_AR = HYGIENE_RULES + `
+- Arabic titles MUST be Arabic script only — no mixed English+Arabic in the title.`;
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -676,7 +690,7 @@ async function generateSocialPost(
     designType?: string;
     slideCount?: number;
   }>(prompt, {
-    systemPrompt: siteConfig?.systemPromptEN || `You are a luxury travel social media writer.`,
+    systemPrompt: (siteConfig?.systemPromptEN || `You are a luxury travel social media writer.`) + HYGIENE_RULES,
     temperature: 0.8,
     maxTokens: 1024,
     taskType: "copywriting",
@@ -732,8 +746,8 @@ async function generateBlogArticle(
     featuredImageBrief: string;
     socialDerivatives?: { platform: string; snippet: string; cta: string }[];
   }>(prompt, {
-    systemPrompt: (language === 'ar' ? siteConfig?.systemPromptAR : siteConfig?.systemPromptEN)
-      || `You are a senior travel content writer specializing in luxury destinations.`,
+    systemPrompt: ((language === 'ar' ? siteConfig?.systemPromptAR : siteConfig?.systemPromptEN)
+      || `You are a senior travel content writer specializing in luxury destinations.`) + (language === 'ar' ? HYGIENE_AR : HYGIENE_RULES),
     temperature: 0.7,
     maxTokens: 8192,
     taskType: "content_generation",
@@ -768,8 +782,8 @@ async function generateEmailCampaign(
     preheader: string;
     blocks: any[];
   }>(prompt, {
-    systemPrompt: (language === 'ar' ? siteConfig?.systemPromptAR : siteConfig?.systemPromptEN)
-      || `You are an email marketing specialist for luxury travel.`,
+    systemPrompt: ((language === 'ar' ? siteConfig?.systemPromptAR : siteConfig?.systemPromptEN)
+      || `You are an email marketing specialist for luxury travel.`) + (language === 'ar' ? HYGIENE_AR : HYGIENE_RULES),
     temperature: 0.7,
     maxTokens: 4096,
     taskType: "copywriting",
@@ -802,8 +816,8 @@ async function generateVideoScript(
       transition: string;
     }[];
   }>(prompt, {
-    systemPrompt: (language === 'ar' ? siteConfig?.systemPromptAR : siteConfig?.systemPromptEN)
-      || `You are a video content creator for luxury travel.`,
+    systemPrompt: ((language === 'ar' ? siteConfig?.systemPromptAR : siteConfig?.systemPromptEN)
+      || `You are a video content creator for luxury travel.`) + (language === 'ar' ? HYGIENE_AR : HYGIENE_RULES),
     temperature: 0.8,
     maxTokens: 2048,
     taskType: "video_generation",

--- a/yalla_london/app/lib/content-pipeline/constants.ts
+++ b/yalla_london/app/lib/content-pipeline/constants.ts
@@ -212,6 +212,12 @@ export const ENHANCEMENT_OWNERS: Record<string, string> = {
   cannibalization_resolution: "seo-agent",
   affiliate_disclosure: "content-auto-fix",
   image_alt_text: "content-auto-fix-lite",
+  // May 17 2026 re-audit additions
+  markdown_tables: "content-auto-fix",
+  bracket_placeholders: "content-auto-fix",
+  mojibake_repair: "content-auto-fix",
+  title_resanitization: "content-auto-fix-lite",
+  event_dedup: "content-auto-fix-lite",
 };
 
 // ─── Escalation Policy ──────────────────────────────────────────────────────

--- a/yalla_london/app/lib/content-pipeline/phases.ts
+++ b/yalla_london/app/lib/content-pipeline/phases.ts
@@ -105,6 +105,27 @@ Use these mandatory Arabic content directives:
 IMPORTANT: Use SINGLE QUOTES for ALL HTML attributes (e.g., <a href='https://...'> NOT <a href="https://...">). Double quotes inside HTML will break JSON output.`;
 }
 
+/**
+ * Template hygiene rules — universal across every AI generation prompt.
+ * Catches recurring bugs from the May 17 2026 re-audit:
+ *   - "high hotel prices with [x] unexpected add-on costs" (unfilled bracket placeholder)
+ *   - "Best Halal Afternoon Tea London V2: Ultimate" (content-versioning slug leak)
+ *   - "London Marathon Guide 2025: Training," (trailing punctuation)
+ *   - "high hotel prices with [x]" rendering as Arabic hero (English-on-AR-locale leak)
+ *
+ * Appended to EVERY system prompt in the content pipeline so the model can't
+ * forget the rules between phases.
+ */
+function getTemplateHygieneDirectives(locale: string): string {
+  return `
+
+TITLE & CONTENT HYGIENE RULES — STRICT, NO EXCEPTIONS:
+- NEVER use bracket placeholders like [x], [X], [TBD], [TODO], [insert ...], [topic], [destination], [keyword], [number], [hotel], [restaurant]. Fill with the actual value or omit the sentence entirely.
+- NEVER append versioning suffixes like "V2", "V3", "v2", "(v2)", "-v3", "Version 2". These are internal tracking; never publish-visible.
+- NEVER end titles with trailing comma, semicolon, colon, pipe, or dash. Titles must end in a meaningful word.
+${isArabic(locale) ? "- Arabic titles MUST be in Arabic script only. NO mixed English+Arabic in the title field. Place names (e.g., Mayfair) inside the title are OK but the structural words must be Arabic." : ""}`;
+}
+
 function getLocaleLabel(locale: string): string {
   return isArabic(locale) ? "Arabic (original, not translated)" : "English";
 }
@@ -183,7 +204,7 @@ Return JSON:
   try {
     const researchTimeout = budgetRemainingMs !== undefined ? Math.max(budgetRemainingMs - 5_000, 10_000) : 25_000;
     const research = await generateJSON<Record<string, unknown>>(prompt, {
-      systemPrompt: `You are a travel SEO researcher for the ${site.destination} market targeting all international visitors and tourists. Return only valid JSON. All string values must be properly escaped.${getLocaleDirectives(draft.locale, site)}`,
+      systemPrompt: `You are a travel SEO researcher for the ${site.destination} market targeting all international visitors and tourists. Return only valid JSON. All string values must be properly escaped.${getLocaleDirectives(draft.locale, site)}${getTemplateHygieneDirectives(draft.locale)}`,
       maxTokens: isArabic(draft.locale) ? 3500 : 1500,
       temperature: 0.4,
       timeoutMs: researchTimeout,
@@ -335,7 +356,7 @@ ${isArabic(draft.locale) ? "ALL headings, key points, and text MUST be in Arabic
 
 AUTHENTICITY: Include 1 sensory/experiential detail per section, 1 insider tip per section, 1 honest caveat, price details (£/€/$) in 3+ sections.${isArabic(draft.locale) ? " Arabic: use نصيحة/نصيحتنا for tips, رائحة/مذاق/أجواء for sensory." : ""}
 GEO CITABILITY: 1+ statistic per section, 2+ source attributions, 40-80 word self-contained opening paragraphs, 1+ comparison table.
-Return only valid JSON. All string values must be properly escaped.${getLocaleDirectives(draft.locale, site)}`,
+Return only valid JSON. All string values must be properly escaped.${getLocaleDirectives(draft.locale, site)}${getTemplateHygieneDirectives(draft.locale)}`,
       maxTokens: isArabic(draft.locale) ? 3500 : 1200,
       temperature: 0.5,
       timeoutMs: outlineTimeout,
@@ -545,7 +566,7 @@ CRITICAL JSON RULES:
         const timeoutCap = isArabic(draft.locale) ? 80_000 : 65_000;
         const sectionTimeout = Math.min(rawTimeout, timeoutCap);
         const result = await generateJSON<Record<string, unknown>>(prompt, {
-          systemPrompt: `You are a travel writer creating content for all visitors and tourists. Write engaging, detailed, SEO-optimized content with genuine depth and specific local knowledge. Each section must meet the minimum word count. Use HTML formatting. Return ONLY valid JSON — all string values must have newlines escaped as \\n and quotes escaped as \\". Never include raw line breaks inside JSON string values.${workflowDirective}${getLocaleDirectives(draft.locale, site)}`,
+          systemPrompt: `You are a travel writer creating content for all visitors and tourists. Write engaging, detailed, SEO-optimized content with genuine depth and specific local knowledge. Each section must meet the minimum word count. Use HTML formatting. Return ONLY valid JSON — all string values must have newlines escaped as \\n and quotes escaped as \\". Never include raw line breaks inside JSON string values.${workflowDirective}${getLocaleDirectives(draft.locale, site)}${getTemplateHygieneDirectives(draft.locale)}`,
           maxTokens: useMinimalPrompt ? 1000 : isArabic(draft.locale) ? 3500 : 1500,
           temperature: 0.7,
           timeoutMs: sectionTimeout,
@@ -693,7 +714,18 @@ export async function phaseAssembly(
       fallbackHtml += `<h2>${isArabic(draft.locale) ? "الخلاصة" : "Conclusion"}</h2>\n<p>${conclusion.callToAction}</p>\n`;
     fallbackHtml += `</article>`;
 
-    const fallbackWords = fallbackHtml
+    // Convert any pipe tables that came through the raw drafting output.
+    // Same logic as the AI assembly path below — ensures raw-fallback content
+    // also gets proper <table> semantics.
+    const { convertPipeTables, hasPipeTable, unwrapPipeParagraphs } = await import(
+      "@/lib/markdown/pipe-tables"
+    );
+    const fallbackUnwrapped = unwrapPipeParagraphs(fallbackHtml);
+    const fallbackNormalized = hasPipeTable(fallbackUnwrapped)
+      ? convertPipeTables(fallbackUnwrapped)
+      : fallbackHtml;
+
+    const fallbackWords = fallbackNormalized
       .replace(/<[^>]+>/g, " ")
       .trim()
       .split(/\s+/)
@@ -701,7 +733,7 @@ export async function phaseAssembly(
     return {
       success: true,
       nextPhase: "images",
-      data: { assembled_html: fallbackHtml, word_count: fallbackWords },
+      data: { assembled_html: fallbackNormalized, word_count: fallbackWords },
       aiModelUsed: "fallback-raw",
     };
   }
@@ -768,7 +800,7 @@ Return JSON:
     const bufferMs = isArabic(draft.locale) ? 3_000 : 5_000;
     const assemblyTimeout = budgetRemainingMs !== undefined ? Math.max(budgetRemainingMs - bufferMs, 10_000) : 30_000;
     const result = await generateJSON<Record<string, unknown>>(prompt, {
-      systemPrompt: `You are a luxury travel senior editor. Polish articles for quality, coherence, and SEO. The final article MUST be at least 1,500 words — expand content if the raw input is too short. Return only valid JSON.${getLocaleDirectives(draft.locale, site)}`,
+      systemPrompt: `You are a luxury travel senior editor. Polish articles for quality, coherence, and SEO. The final article MUST be at least 1,500 words — expand content if the raw input is too short. Return only valid JSON.${getLocaleDirectives(draft.locale, site)}${getTemplateHygieneDirectives(draft.locale)}`,
       maxTokens: isArabic(draft.locale) ? 1500 : 1000,
       temperature: 0.4,
       timeoutMs: assemblyTimeout,
@@ -779,7 +811,16 @@ Return JSON:
     });
 
     const { sanitizeContentBody } = await import("@/lib/content-pipeline/title-sanitizer");
-    const assembledHtml = sanitizeContentBody((result.html as string) || rawHtml);
+    const { convertPipeTables, hasPipeTable, unwrapPipeParagraphs } = await import(
+      "@/lib/markdown/pipe-tables"
+    );
+    // Sanitize first (strips bracket placeholders + word counts), then convert pipe tables.
+    // AI sometimes emits "<p>| Col | Col |</p>" — unwrapPipeParagraphs makes those detectable.
+    const sanitizedHtml = sanitizeContentBody((result.html as string) || rawHtml);
+    const unwrappedHtml = unwrapPipeParagraphs(sanitizedHtml);
+    const assembledHtml = hasPipeTable(unwrappedHtml)
+      ? convertPipeTables(unwrappedHtml)
+      : sanitizedHtml;
     let assembledWordCount = (result.wordCount as number) || totalWords;
 
     // Verify actual word count (AI sometimes lies about wordCount in JSON)
@@ -820,7 +861,7 @@ Return JSON:
 
         const expansionTimeout = freshBudgetMs !== undefined ? Math.max(freshBudgetMs - 5_000, 10_000) : 25_000;
         const expansionResult = await generateJSON<Record<string, unknown>>(expansionPrompt, {
-          systemPrompt: `You are a luxury travel editor. Expand articles to meet minimum word counts while maintaining quality. Return only valid JSON.${getLocaleDirectives(draft.locale, site)}`,
+          systemPrompt: `You are a luxury travel editor. Expand articles to meet minimum word counts while maintaining quality. Return only valid JSON.${getLocaleDirectives(draft.locale, site)}${getTemplateHygieneDirectives(draft.locale)}`,
           maxTokens: isArabic(draft.locale) ? 3500 : 2000,
           temperature: 0.5,
           timeoutMs: expansionTimeout,
@@ -1185,7 +1226,7 @@ Return JSON:
   try {
     const seoTimeout = budgetRemainingMs !== undefined ? Math.max(budgetRemainingMs - 5_000, 10_000) : 25_000;
     const seoResult = await generateJSON<Record<string, unknown>>(prompt, {
-      systemPrompt: `You are a technical SEO specialist for luxury travel. Optimize metadata for maximum search visibility. Return only valid JSON. All string values must be properly escaped.${isArabic(draft.locale) ? " Arabic meta tags should be in Arabic." : ""}`,
+      systemPrompt: `You are a technical SEO specialist for luxury travel. Optimize metadata for maximum search visibility. Return only valid JSON. All string values must be properly escaped.${isArabic(draft.locale) ? " Arabic meta tags should be in Arabic." : ""}${getTemplateHygieneDirectives(draft.locale)}`,
       maxTokens: isArabic(draft.locale) ? 1800 : 1200,
       temperature: 0.3,
       timeoutMs: seoTimeout,

--- a/yalla_london/app/lib/content-pipeline/title-sanitizer.ts
+++ b/yalla_london/app/lib/content-pipeline/title-sanitizer.ts
@@ -58,6 +58,22 @@ const TRAILING_PIPE = /\s*\|+\s*$/;
 const EMPTY_PARENS = /\s*\(\s*\)\s*$/;
 const TRAILING_COLON = /\s*:\s*$/;
 
+// Trailing comma/semicolon (Marathon: "Training,") — May 17 2026 re-audit
+const TRAILING_PUNCTUATION = /\s*[,;]+\s*$/;
+
+// Versioning slugs leaked from content-strategy ("V2", "V3", "(v2)", "-v3", "Version 2")
+// Lookahead keeps colon-separated subtitles intact: matches " V2" only before ":" or end-of-string.
+// Examples stripped: "Best London Hotels V2: Ultimate", "Guide v3", "Title (V2)"
+// NOTE: Two variants — non-/g for stateful .test(), /g for .replace() (see file header rule).
+const VERSION_SUFFIX = /\s+[Vv](?:ersion)?[\s-]?\d{1,2}\b(?=[\s:]|$)/;
+const VERSION_SUFFIX_G = /\s+[Vv](?:ersion)?[\s-]?\d{1,2}\b(?=[\s:]|$)/g;
+
+// Bracket placeholders AI never filled. Enumerates known placeholder words so we
+// don't strip legitimate didactic markers like [example] or citation markers [1].
+// Examples: "[x]", "[X]", "[TBD]", "[insert hotel name]", "[topic]", "[destination]"
+const BRACKET_PLACEHOLDER = /\[(?:x|X|\.\.\.|TBD|TODO|placeholder|insert[^\]]*|topic|destination|keyword|number|date|year|month|brand|hotel|restaurant)\]/i;
+const BRACKET_PLACEHOLDER_G = /\[(?:x|X|\.\.\.|TBD|TODO|placeholder|insert[^\]]*|topic|destination|keyword|number|date|year|month|brand|hotel|restaurant)\]/gi;
+
 // "for arabs" / "for arab travellers" stuffed at end is low-value English-SERP
 // keyword — niche audience already covered by Arabic /ar/ pages with hreflang.
 // Removing it earns ~0.4 percentage points of CTR per Backlinko study (shorter
@@ -112,6 +128,20 @@ export function sanitizeTitle(title: string): string {
 
   // Strip trailing colon
   cleaned = cleaned.replace(TRAILING_COLON, "").trim();
+
+  // Strip trailing comma/semicolon (May 17 re-audit: Marathon "Training,")
+  cleaned = cleaned.replace(TRAILING_PUNCTUATION, "").trim();
+
+  // Strip versioning slug leaks ("V2", "V3"). Must run before re-collapsing whitespace
+  // so the space before "V2" is also removed by the trim() after.
+  cleaned = cleaned.replace(VERSION_SUFFIX_G, "").trim();
+
+  // Strip unfilled bracket placeholders ("[x]", "[TBD]", "[insert ...]"). Enumerated
+  // list keeps legitimate markers like "[example]" or "[1]" intact.
+  cleaned = cleaned.replace(BRACKET_PLACEHOLDER_G, "").trim();
+
+  // Re-collapse whitespace after stripping (placeholders may leave double spaces)
+  cleaned = cleaned.replace(/\s{2,}/g, " ").trim();
 
   // Strip trailing punctuation artifacts (e.g., " -" or " |" left after stripping)
   cleaned = cleaned.replace(/\s*[|–-]\s*$/, "").trim();
@@ -202,6 +232,10 @@ export function sanitizeContentBody(html: string): string {
   // Remove labeled word counts: "(Word count: 248)"
   cleaned = cleaned.replace(WORD_COUNT_LABELED, "");
 
+  // Strip unfilled bracket placeholders from body content ("[x]", "[TBD]", "[insert ...]")
+  // May 17 re-audit: "high hotel prices with [x] unexpected add-on costs"
+  cleaned = cleaned.replace(BRACKET_PLACEHOLDER_G, "");
+
   // Clean up any resulting empty paragraphs
   cleaned = cleaned.replace(/<p[^>]*>\s*<\/p>/gi, "");
 
@@ -237,7 +271,21 @@ export function hasTitleArtifacts(title: string): boolean {
     TRAILING_ARAB_STUFF.test(title) ||
     TRAILING_YEAR.test(title) ||
     DUPLICATED_SUBTITLE.test(title) ||
+    // May 17 2026 re-audit patterns
+    TRAILING_PUNCTUATION.test(title) ||
+    VERSION_SUFFIX.test(title) ||
+    BRACKET_PLACEHOLDER.test(title) ||
     // Starts with "EXPAND:" leak from content-strategy
     /^EXPAND:\s*/i.test(title)
   );
+}
+
+/**
+ * Check if text contains an unfilled bracket placeholder ([x], [TBD], [insert ...]).
+ * Used by pre-publication-gate to block template leaks at publish time.
+ * Returns false for legitimate markers like [example] or citation markers [1].
+ */
+export function hasBracketPlaceholder(text: string): boolean {
+  if (!text) return false;
+  return BRACKET_PLACEHOLDER.test(text);
 }

--- a/yalla_london/app/lib/markdown/pipe-tables.ts
+++ b/yalla_london/app/lib/markdown/pipe-tables.ts
@@ -1,0 +1,91 @@
+/**
+ * Pipe-table markdown → HTML <table> converter.
+ *
+ * Extracted from BlogPostClient.tsx (May 17 2026 re-audit) so both the assembly
+ * phase (lib/content-pipeline/phases.ts) and the render layer can share the
+ * same conversion. Without assembly-side conversion, pipe-table syntax could
+ * ship in the BlogPost.content_en/ar field; the render layer would still catch
+ * it via convertPipeTables, but only when running through markdownToHtml. AI
+ * assemblies often emit `<p>| Col | Col |</p>` (wrapped), which the markdown
+ * detector skips — so the assembly phase must unwrap+convert at write time.
+ *
+ * Pattern: GFM-style pipe tables: `| col | col |` + `|---|---|` separator row.
+ * Walks lines, identifies contiguous table blocks, emits semantic
+ * <thead>/<tbody>. Lines outside table blocks are returned unchanged.
+ */
+
+const isRow = (s: string): boolean =>
+  /^\s*\|.*\|\s*$/.test(s) && s.includes("|", s.indexOf("|") + 1);
+
+const isSep = (s: string): boolean =>
+  /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/.test(s);
+
+const cellsFrom = (s: string): string[] =>
+  s
+    .replace(/^\s*\|/, "")
+    .replace(/\|\s*$/, "")
+    .split("|")
+    .map((c) => c.trim());
+
+/**
+ * Convert GFM-style pipe tables to HTML <table>.
+ * Idempotent — safe to call on mixed markdown+HTML content.
+ */
+export function convertPipeTables(input: string): string {
+  if (!input) return input;
+
+  const lines = input.split(/\r?\n/);
+  const out: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const header = lines[i];
+    const sep = lines[i + 1] || "";
+    if (isRow(header) && isSep(sep)) {
+      const headerCells = cellsFrom(header);
+      const rows: string[][] = [];
+      let j = i + 2;
+      while (j < lines.length && isRow(lines[j])) {
+        rows.push(cellsFrom(lines[j]));
+        j++;
+      }
+      const thead = `<thead><tr>${headerCells
+        .map((c) => `<th>${c}</th>`)
+        .join("")}</tr></thead>`;
+      const tbody = rows.length
+        ? `<tbody>${rows
+            .map(
+              (r) =>
+                `<tr>${r.map((c) => `<td>${c}</td>`).join("")}</tr>`,
+            )
+            .join("")}</tbody>`
+        : "";
+      out.push(`<table class="md-table">${thead}${tbody}</table>`);
+      i = j;
+    } else {
+      out.push(header);
+      i++;
+    }
+  }
+
+  return out.join("\n");
+}
+
+/**
+ * Detect whether a string contains any GFM pipe-table syntax.
+ * Used by the assembly phase as a fast pre-filter before calling convertPipeTables.
+ */
+export function hasPipeTable(s: string): boolean {
+  if (!s) return false;
+  return /(?:^|\n)[ \t]*\|[^\n]+\|[ \t]*\n[ \t]*\|[\s\-:|]+\|/.test(s);
+}
+
+/**
+ * Unwrap <p>-wrapped pipe rows so detection works.
+ * AI assemblies sometimes emit `<p>| Col | Col |</p>` — the regex in hasPipeTable
+ * requires newlines between rows, which <p> wrapping breaks.
+ */
+export function unwrapPipeParagraphs(html: string): string {
+  if (!html) return html;
+  return html.replace(/<p>(\s*\|[^<]+\|\s*)<\/p>/g, "$1\n");
+}

--- a/yalla_london/app/lib/seo/orchestrator/pre-publication-gate.ts
+++ b/yalla_london/app/lib/seo/orchestrator/pre-publication-gate.ts
@@ -127,6 +127,62 @@ export async function runPrePublicationGate(
     warnings.push(artifactCheck.message);
   }
 
+  // ── Check 17: Bracket placeholder leak (May 17 2026 re-audit) ────────
+  // AI sometimes leaves unfilled bracket placeholders like [x], [TBD], [insert hotel name].
+  // Title-level placeholders are publication blockers (visible in SERP, huge UX harm).
+  // Body-level placeholders warn (content-auto-fix Section 28 strips them post-hoc).
+  const { hasBracketPlaceholder } = await import(
+    "@/lib/content-pipeline/title-sanitizer"
+  );
+  const placeholderFields: Array<
+    [string, string | null | undefined, "blocker" | "warning"]
+  > = [
+    ["title_en", content.title_en, "blocker"],
+    ["title_ar", content.title_ar, "blocker"],
+    ["meta_description_en", content.meta_description_en, "warning"],
+    ["content_en", content.content_en, "warning"],
+    ["content_ar", content.content_ar, "warning"],
+  ];
+  for (const [name, value, severity] of placeholderFields) {
+    if (value && hasBracketPlaceholder(value)) {
+      const placeholderCheck: GateCheck = {
+        name: "Placeholder Leak",
+        passed: false,
+        message: `Field ${name} contains unfilled bracket placeholder (e.g. [x], [TBD], [insert ...])`,
+        severity,
+      };
+      checks.push(placeholderCheck);
+      if (severity === "blocker") {
+        blockers.push(placeholderCheck.message);
+      } else {
+        warnings.push(placeholderCheck.message);
+      }
+      break; // one notice is enough per article
+    }
+  }
+
+  // ── Check 18: Arabic language coherence ──────────────────────────────
+  // Drafts marked locale=ar with content_ar must be majority Arabic script.
+  // Catches "Arabic" content that's actually 50%+ English (broken translation,
+  // raw English with token-substitution failures). Threshold 0.6 tolerates
+  // place names ("Mayfair", hotel names) up to 40% Latin.
+  if (content.locale === "ar" && content.content_ar) {
+    const stripped = content.content_ar.replace(/<[^>]+>/g, "").replace(/\s+/g, "");
+    const arabicChars = (stripped.match(/[؀-ۿ]/g) || []).length;
+    const totalChars = stripped.length || 1;
+    const arabicRatio = arabicChars / totalChars;
+    if (arabicRatio < 0.6) {
+      const arCoherenceCheck: GateCheck = {
+        name: "Arabic Language Ratio",
+        passed: false,
+        message: `Arabic content is only ${(arabicRatio * 100).toFixed(0)}% Arabic script (need 60%+) — English contamination detected`,
+        severity: "blocker",
+      };
+      checks.push(arCoherenceCheck);
+      blockers.push(arCoherenceCheck.message);
+    }
+  }
+
   // ── 1. Route existence check ────────────────────────────────────────
   // Verify the target URL will actually resolve (not return 404)
   // Skipped during bulk audits (skipRouteCheck) to avoid slow HTTP calls

--- a/yalla_london/app/lib/utils/mojibake.ts
+++ b/yalla_london/app/lib/utils/mojibake.ts
@@ -1,0 +1,84 @@
+/**
+ * Mojibake repair — undo UTF-8 ↔ Latin-1 double-encoding.
+ *
+ * Mojibake happens when UTF-8 bytes are interpreted as Latin-1 (single byte per
+ * char) and then re-encoded as UTF-8. Classic examples:
+ *   - "Colón"  (correct)
+ *   - "Colã³n" (mojibake)
+ *   - "café"   (correct)
+ *   - "cafÃ©"  (mojibake)
+ *
+ * Detection signal: the string contains `Ã` (capital A-tilde) or `â€` (a-circumflex
+ * followed by Euro sign) — both byte patterns that would never appear in
+ * properly-encoded UTF-8 unless the source was a mis-encoded round-trip.
+ *
+ * Repair: re-interpret the string as Latin-1 bytes, then decode as UTF-8.
+ * The result is validated to ensure the decode actually produced valid characters
+ * (Arabic, Latin accents). If validation fails, the original string is returned
+ * unchanged — never make it worse.
+ *
+ * May 17 2026 re-audit caught "Willie Colã³N" on /events.
+ */
+
+/**
+ * Detect if a string likely contains mojibake.
+ * Cheap pre-filter to avoid Buffer allocation on every clean string.
+ */
+export function hasMojibake(s: string): boolean {
+  if (!s) return false;
+  return /Ã[-¿]/.test(s) || /â€/.test(s);
+}
+
+/**
+ * Repair a mojibake-encoded string. Idempotent and safe:
+ *   - Returns the original string if no mojibake detected.
+ *   - Returns the original string if repair produces a worse result.
+ *   - NFC-normalizes the decoded output for downstream consistency.
+ *
+ * Examples:
+ *   repairMojibake("Willie Colã³n") === "Willie Colón"
+ *   repairMojibake("Café Brûlé")     === "Café Brûlé"  (already clean → unchanged)
+ *   repairMojibake("")               === ""
+ */
+export function repairMojibake(s: string): string {
+  if (!s || !hasMojibake(s)) return s;
+  try {
+    const decoded = Buffer.from(s, "latin1").toString("utf8");
+    // Validate: must contain accented Latin (À-ſ) or Arabic (؀-ۿ), AND must not
+    // still contain the mojibake markers. Otherwise we made it worse.
+    const hasValidChars = /[À-ſ؀-ۿ]/.test(decoded);
+    const stillBroken = /Ã[-¿]/.test(decoded) || /â€/.test(decoded);
+    if (hasValidChars && !stillBroken) {
+      return decoded.normalize("NFC");
+    }
+  } catch {
+    // Buffer.from / toString errors mean the input wasn't a valid Latin-1
+    // re-interpretation — fall through and return original.
+  }
+  return s;
+}
+
+/**
+ * Apply mojibake repair to a record object, returning the diff.
+ * Useful when scanning DB rows where most fields are clean.
+ *
+ * Returns null if no field was changed (caller can skip the DB update).
+ * Otherwise returns an object containing only the repaired fields.
+ */
+export function repairRecord<T extends Record<string, string | null | undefined>>(
+  record: T,
+  fields: Array<keyof T>,
+): Partial<T> | null {
+  const diff: Partial<T> = {};
+  let changed = false;
+  for (const field of fields) {
+    const value = record[field];
+    if (typeof value !== "string" || !value) continue;
+    const repaired = repairMojibake(value);
+    if (repaired !== value) {
+      (diff as Record<string, string>)[field as string] = repaired;
+      changed = true;
+    }
+  }
+  return changed ? diff : null;
+}

--- a/yalla_london/app/scripts/smoke-test.ts
+++ b/yalla_london/app/scripts/smoke-test.ts
@@ -2369,6 +2369,137 @@ test("Prisma Field Sanity", "discovery scanner uses getCachedSitemap (not raw si
     : { status: WARN, details: "No sitemap cache check found" };
 });
 
+// ─── May 17 2026 re-audit regression tests ─────────────────────────────────
+// Each test asserts a fix from /root/.claude/plans/i-want-you-to-dazzling-yeti.md.
+// Pattern tests catch silent regressions if someone reverts the sanitizer or
+// removes a cron section. Run as part of every smoke-test pass.
+
+test("Audit-May17-Regression", "sanitizeTitle strips trailing comma + semicolon", () => {
+  return fileContains("lib/content-pipeline/title-sanitizer.ts", "TRAILING_PUNCTUATION")
+    ? { status: PASS, details: "TRAILING_PUNCTUATION regex present" }
+    : { status: FAIL, details: "TRAILING_PUNCTUATION missing — Marathon comma will leak" };
+});
+
+test("Audit-May17-Regression", "sanitizeTitle strips V2/V3 versioning suffix", () => {
+  return fileContains("lib/content-pipeline/title-sanitizer.ts", "VERSION_SUFFIX")
+    ? { status: PASS, details: "VERSION_SUFFIX regex present" }
+    : { status: FAIL, details: "VERSION_SUFFIX missing — 'V2: Ultimate' slug will leak" };
+});
+
+test("Audit-May17-Regression", "sanitizer detects + exports hasBracketPlaceholder", () => {
+  const content = fs.readFileSync(
+    path.join(APP_DIR, "lib/content-pipeline/title-sanitizer.ts"),
+    "utf-8",
+  );
+  return content.includes("BRACKET_PLACEHOLDER") && content.includes("export function hasBracketPlaceholder")
+    ? { status: PASS, details: "" }
+    : { status: FAIL, details: "Bracket placeholder regex or helper missing" };
+});
+
+test("Audit-May17-Regression", "pre-publication-gate Check 17 wired (placeholder leak)", () => {
+  return fileContains("lib/seo/orchestrator/pre-publication-gate.ts", "hasBracketPlaceholder")
+    ? { status: PASS, details: "Check 17 imports hasBracketPlaceholder" }
+    : { status: FAIL, details: "Placeholder check missing in pre-pub gate" };
+});
+
+test("Audit-May17-Regression", "pre-publication-gate Check 18 wired (Arabic ratio)", () => {
+  return fileContains("lib/seo/orchestrator/pre-publication-gate.ts", "Arabic Language Ratio")
+    ? { status: PASS, details: "Check 18 enforces ≥60% Arabic chars on AR drafts" }
+    : { status: FAIL, details: "Arabic ratio gate missing" };
+});
+
+test("Audit-May17-Regression", "Shared pipe-tables module exists with exports", () => {
+  const exists = fileExists("lib/markdown/pipe-tables.ts");
+  if (!exists) return { status: FAIL, details: "lib/markdown/pipe-tables.ts missing" };
+  const content = fs.readFileSync(path.join(APP_DIR, "lib/markdown/pipe-tables.ts"), "utf-8");
+  return content.includes("export function convertPipeTables") &&
+    content.includes("export function hasPipeTable") &&
+    content.includes("export function unwrapPipeParagraphs")
+    ? { status: PASS, details: "All 3 exports present" }
+    : { status: FAIL, details: "Pipe-tables module missing required exports" };
+});
+
+test("Audit-May17-Regression", "phases.ts assembly calls convertPipeTables", () => {
+  return fileContains("lib/content-pipeline/phases.ts", "convertPipeTables")
+    ? { status: PASS, details: "Assembly runs pipe-table conversion at write time" }
+    : { status: FAIL, details: "Assembly missing pipe-table conversion — tables ship raw" };
+});
+
+test("Audit-May17-Regression", "BlogPostClient imports shared pipe-tables lib", () => {
+  return fileContains("app/blog/[slug]/BlogPostClient.tsx", '"@/lib/markdown/pipe-tables"')
+    ? { status: PASS, details: "BlogPostClient uses shared lib (no inline copy drift)" }
+    : { status: FAIL, details: "BlogPostClient missing shared import" };
+});
+
+test("Audit-May17-Regression", "content-auto-fix has Section 27 (pipe tables backfill)", () => {
+  return fileContains("app/api/cron/content-auto-fix/route.ts", "Section 27")
+    ? { status: PASS, details: "" }
+    : { status: FAIL, details: "Section 27 missing — existing posts won't get tables fixed" };
+});
+
+test("Audit-May17-Regression", "content-auto-fix has Section 28 (bracket placeholder body)", () => {
+  return fileContains("app/api/cron/content-auto-fix/route.ts", "Section 28")
+    ? { status: PASS, details: "" }
+    : { status: FAIL, details: "Section 28 missing — body placeholders won't get stripped" };
+});
+
+test("Audit-May17-Regression", "content-auto-fix has Section 29 (mojibake repair)", () => {
+  return fileContains("app/api/cron/content-auto-fix/route.ts", "Section 29")
+    ? { status: PASS, details: "" }
+    : { status: FAIL, details: "Section 29 missing — 'Colã³N' won't get repaired" };
+});
+
+test("Audit-May17-Regression", "content-auto-fix-lite has Section 18 (title resanitization)", () => {
+  return fileContains("app/api/cron/content-auto-fix-lite/route.ts", "Section 18")
+    ? { status: PASS, details: "" }
+    : { status: FAIL, details: "Section 18 missing — old titles won't get re-sanitized" };
+});
+
+test("Audit-May17-Regression", "content-auto-fix-lite has Section 19 (event dedup)", () => {
+  return fileContains("app/api/cron/content-auto-fix-lite/route.ts", "Section 19")
+    ? { status: PASS, details: "" }
+    : { status: FAIL, details: "Section 19 missing — duplicate events won't get cleaned" };
+});
+
+test("Audit-May17-Regression", "yalla-homepage uses strict Arabic-ratio filter", () => {
+  return fileContains("components/home/yalla-homepage.tsx", "isArabicTitleEligible")
+    ? { status: PASS, details: "AR homepage gates by Arabic char ratio + placeholder check" }
+    : { status: FAIL, details: "AR homepage filter not strict — English titles will leak" };
+});
+
+test("Audit-May17-Regression", "/api/events deduplicates by title+venue+date", () => {
+  return fileContains("app/api/events/route.ts", "seenKeys")
+    ? { status: PASS, details: "Composite key dedup at query time" }
+    : { status: FAIL, details: "/api/events missing dedup — duplicates will show" };
+});
+
+test("Audit-May17-Regression", "/hotels has Unsplash photo fallback", () => {
+  return fileContains("app/hotels/hotels-content.tsx", "getFallbackPhoto") &&
+    fileContains("app/hotels/hotels-content.tsx", "naturalWidth === 0")
+    ? { status: PASS, details: "Unsplash fallback + 0×0 detection wired" }
+    : { status: FAIL, details: "/hotels still shows gradient-only cards" };
+});
+
+test("Audit-May17-Regression", "events-sync runs mojibake repair + composite dedup", () => {
+  const content = fs.readFileSync(
+    path.join(APP_DIR, "app/api/cron/events-sync/route.ts"),
+    "utf-8",
+  );
+  return content.includes("repairMojibake") && content.includes("title_en: cleanName")
+    ? { status: PASS, details: "Ingest normalizes text + checks composite key" }
+    : { status: FAIL, details: "events-sync still ingests raw mojibake / no dedup" };
+});
+
+test("Audit-May17-Regression", "partner-detector registers universe + eticketing", () => {
+  const content = fs.readFileSync(
+    path.join(APP_DIR, "lib/affiliate/partner-detector.ts"),
+    "utf-8",
+  );
+  return content.includes("universe.com") && content.includes("eticketing.co.uk")
+    ? { status: PASS, details: "Both partners detected for attribution" }
+    : { status: FAIL, details: "Missing universe/eticketing — clicks unattributed" };
+});
+
 // Compute categories AFTER all tests have run
 const categories = [...new Set(results.map((r) => r.category))];
 let totalPass = 0,


### PR DESCRIPTION
Title sanitizer extensions (lib/content-pipeline/title-sanitizer.ts):
- TRAILING_PUNCTUATION strips trailing comma/semicolon (Marathon "Training,")
- VERSION_SUFFIX strips V2/V3/v2/version 2 slugs ("Best Tea V2: Ultimate")
- BRACKET_PLACEHOLDER strips [x]/[TBD]/[insert ...]/[topic]/[destination]
- Body sanitizer also strips bracket placeholders for content_en/ar
- New export hasBracketPlaceholder() for pre-pub gate reuse
- Non-/g + /g regex variants per file convention (avoids stateful .test())

Pre-publication gate Checks 17 + 18:
- Check 17 blocks title placeholder leak (warning on body)
- Check 18 blocks AR-locale drafts with less than 60% Arabic chars

Pipe-table conversion at assembly time:
- New lib/markdown/pipe-tables.ts with convertPipeTables + hasPipeTable +
  unwrapPipeParagraphs (shared between assembly + render layer)
- phases.ts phaseAssembly + raw-fallback branch detect+convert pipe tables
- BlogPostClient refactored to import shared lib + call unconditionally
  before markdownToHtml (catches <p>-wrapped pipe rows)

AI prompt hygiene:
- New getTemplateHygieneDirectives() appended to all 6 phases.ts prompts
- HYGIENE_RULES + HYGIENE_AR appended to all 4 scripter.ts prompts
- Both article-enhancer.ts prompts updated with hygiene clause
- Rules: forbid bracket placeholders, V2/V3 suffixes, trailing punctuation;
  Arabic titles must be Arabic-script only

Partner detector additions:
- universe.com, eticketing.co.uk, ticketmaster registered for click
  attribution (commission requires manual signup — deferred)

Mojibake utility:
- New lib/utils/mojibake.ts with repairMojibake() + repairRecord()
- Safe-by-default: only rewrites when decode produces valid chars AND
  removes mojibake markers; preserves original on validation failure
- Shared by content-auto-fix Section 29 and events-sync ingest

Constants:
- Register markdown_tables, bracket_placeholders, mojibake_repair,
  title_resanitization, event_dedup in ENHANCEMENT_OWNERS

https://claude.ai/code/session_015edNcZx4zUeuwpfoRhVFuJ