### PR TITLE
feat(yl): IndexNow filter + empty-ID guard + hreflang + image backfill + RLS Batch A

### DIFF
--- a/yalla_london/app/app/api/cron/affiliate-injection/route.ts
+++ b/yalla_london/app/app/api/cron/affiliate-injection/route.ts
@@ -1212,9 +1212,16 @@ function findMatches(content: string, siteId: string, limit = 4, dbRules?: Affil
     let skippedEmpty = 0;
     for (const aff of rule.affiliates) {
       // Skip affiliates with empty tracking params (env var not set — we're not approved yet)
-      // This prevents showing partner names like "Booking.com" when we have no commission tracking
+      // This prevents showing partner names like "Booking.com" when we have no commission tracking.
+      //
+      // YL-2 hardening: also guard against multi-value param strings where ANY
+      // segment has an empty trailing value (e.g. `?aid=&utm_source=site` or
+      // `?cid=&sub=`). The original `endsWith("=")` check missed these, so a
+      // multi-param template with one unset env var still leaked through and
+      // produced a dead link.
       const paramValue = aff.param.split("=").pop() || "";
-      if (!paramValue || aff.param.endsWith("=") || aff.param.endsWith("=''") || aff.param.endsWith('=""')) {
+      const hasEmptySegment = /[?&][^=&]+=(?=$|&)/.test(aff.param);
+      if (!paramValue || aff.param.endsWith("=") || aff.param.endsWith("=''") || aff.param.endsWith('=""') || hasEmptySegment) {
         skippedEmpty++;
         continue;
       }

--- a/yalla_london/app/app/api/cron/image-pipeline/route.ts
+++ b/yalla_london/app/app/api/cron/image-pipeline/route.ts
@@ -206,6 +206,90 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // ── Step 1.7: Inline-image backfill for published articles ────────
+    // YL-2 image-pipeline extension. Many articles have a featured image but
+    // no inline <img> in the body — hurts dwell time, accessibility, and
+    // image-search discoverability. Each run picks up to 20 published posts
+    // whose body has zero <img> tags, fetches ONE topical Unsplash photo via
+    // the existing pipeline, and splices it after the first paragraph.
+    //
+    // Reuses searchPhotos + buildImageUrl + saveToLibrary — no new model
+    // integration. Stays within the existing 280s budget + Unsplash rate
+    // limit (cap = 20 across all sites per invocation).
+    let inlineBackfillCap = 20;
+    for (const siteId of activeSites) {
+      if (Date.now() - startTime > BUDGET_MS) break;
+      if (inlineBackfillCap <= 0) break;
+
+      const siteConfig = getSiteConfig(siteId);
+      const destination = siteConfig?.destination || "London";
+
+      // Heuristic: HTML bodies without "<img" almost certainly have no inline
+      // image. Featured-image hero is rendered separately in the layout, so a
+      // missing inline image leaves the body wall-of-text.
+      const candidates = await prisma.blogPost.findMany({
+        where: {
+          siteId,
+          published: true,
+          NOT: { content_en: { contains: "<img" } },
+        },
+        select: { id: true, slug: true, title_en: true, content_en: true },
+        take: inlineBackfillCap,
+        orderBy: { updated_at: "desc" },
+      });
+
+      for (const post of candidates) {
+        if (Date.now() - startTime > BUDGET_MS) break;
+        if (inlineBackfillCap <= 0) break;
+
+        try {
+          const query = `${destination} ${post.title_en.replace(/[^\w\s]/g, "")}`.substring(0, 80);
+          const photos = await searchPhotos(query, { perPage: 4, orientation: "landscape" });
+          if (photos.length === 0) continue;
+
+          const photo = photos[0];
+          const imageUrl = buildImageUrl(photo.urls.raw, { width: 1200, quality: 80, format: "webp" });
+          const attribution = buildAttribution(photo);
+          const altText = (post.title_en || destination).slice(0, 120).replace(/"/g, "&quot;");
+          const figureHtml =
+            `
+<figure class="article-inline-image" style="margin: 1.5rem 0;">` +
+            `<img src="${imageUrl}" alt="${altText}" loading="lazy" style="width:100%;height:auto;border-radius:8px;" />` +
+            `<figcaption style="font-size:0.8rem;color:#6b7280;margin-top:0.4rem;">${attribution}</figcaption>` +
+            `</figure>
+`;
+
+          // Splice after the first </p> when present, else prepend.
+          const body = post.content_en || "";
+          const firstP = body.indexOf("</p>");
+          const updatedBody =
+            firstP >= 0
+              ? body.slice(0, firstP + 4) + figureHtml + body.slice(firstP + 4)
+              : figureHtml + body;
+
+          await prisma.blogPost.update({
+            where: { id: post.id },
+            data: { content_en: updatedBody },
+          });
+
+          await saveToLibrary(prisma as Record<string, unknown>, photo, imageUrl, attribution, query, siteId);
+          imagesAdded++;
+          articlesUpdated++;
+          inlineBackfillCap--;
+
+          if (photo.downloadUrl) {
+            trackDownload(photo.downloadUrl).catch(() => {});
+          }
+        } catch (inlineErr) {
+          errors++;
+          console.warn(
+            `[image-pipeline] Inline backfill failed for ${post.slug}:`,
+            inlineErr instanceof Error ? inlineErr.message : String(inlineErr),
+          );
+        }
+      }
+    }
+
     // ── Step 2: Pre-stock library with per-site travel imagery ────────
     // Pick 1 random query per site per run (stays within rate limits)
     for (const siteId of activeSites) {

--- a/yalla_london/app/app/api/cron/process-indexing-queue/route.ts
+++ b/yalla_london/app/app/api/cron/process-indexing-queue/route.ts
@@ -96,14 +96,20 @@ async function handleProcessQueue(request: NextRequest) {
         }
 
         // ── 2. Find URLs that need submission ──
-        // Get "discovered" URLs that haven't been submitted via any channel yet
+        // Get "discovered" URLs that haven't been submitted via any channel yet.
+        //
+        // YL-2 fix: dropped `submitted_sitemap: false` from the WHERE clause.
+        // Sitemap submission goes to Google only and doesn't notify Bing/Yandex,
+        // so URLs flagged `submitted_sitemap: true` were silently excluded from
+        // the IndexNow push and never made it to Bing/Yandex — leaving ~476 URLs
+        // stranded. Direct IndexNow + Google Indexing API are still gated, so
+        // we won't re-submit URLs that already went through those channels.
         const pendingUrls = await prisma.uRLIndexingStatus.findMany({
           where: {
             site_id: siteId,
             status: { in: ["discovered", "pending"] },
             submitted_indexnow: false,
             submitted_google_api: false,
-            submitted_sitemap: false,
             submission_attempts: { lt: INDEXNOW_CHRONIC_FAILURE_CAP }, // Skip chronic failures — wastes crawl budget
           },
           select: { url: true, id: true },

--- a/yalla_london/app/app/page.tsx
+++ b/yalla_london/app/app/page.tsx
@@ -56,7 +56,11 @@ export async function generateMetadata(): Promise<Metadata> {
         "London travel",
         "Maldives resorts",
       ],
-      alternates: { canonical: baseUrl },
+      // YL-2 hreflang patch: reuse the locale-aware rootAlternates helper so
+      // the parent-brand portal exposes en-GB/ar-SA + x-default like every
+      // other public page. Previously this returned canonical-only, hiding
+      // the AR landing from Google's hreflang graph entirely.
+      alternates: rootAlternates,
       openGraph: {
         title,
         description,

--- a/yalla_london/app/prisma/migrations/20260610_rls_batch_a/migration.sql
+++ b/yalla_london/app/prisma/migrations/20260610_rls_batch_a/migration.sql
@@ -1,0 +1,21 @@
+-- RLS Batch A — enable Row Level Security on 6 advisor-flagged tables.
+--
+-- Convention: RLS is enabled with NO policies. The Supabase service_role
+-- bypasses RLS by default, so the Prisma client (which uses DATABASE_URL
+-- with service-role credentials) keeps working unchanged. The
+-- anon/authenticated roles get blocked from these tables — they were
+-- never read directly from the browser anyway (verified via codebase
+-- audit: no `supabase.from('<table>')` calls reach these).
+--
+-- Highest priority is `google_drive_accounts` — currently leaks OAuth
+-- access/refresh tokens. The other five are cron/agent infrastructure
+-- with no expected impact.
+--
+-- Idempotent: ENABLE ROW LEVEL SECURITY is safe to re-run.
+
+ALTER TABLE "google_drive_accounts" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "finance_events" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "agent_tasks" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "daily_briefings" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "chrome_audit_reports" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "unsplash_cache" ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Lands four YL-2 hygiene patches plus RLS hardening Batch A on six advisor-flagged tables. One PR, smallest viable diffs, no new deps, no workflow changes.

## Patch 1 — IndexNow filter fix (+8 / -2)
**File:** `yalla_london/app/app/api/cron/process-indexing-queue/route.ts`

Dropped `submitted_sitemap: false` from the `URLIndexingStatus` `WHERE` clause. Sitemap submission notifies Google only — it does NOT push URLs to Bing/Yandex. URLs that had been sitemap-submitted were therefore silently excluded from the direct IndexNow push and never made it to Bing/Yandex, stranding ~476 URLs. The remaining `submitted_indexnow: false` + `submitted_google_api: false` gates already prevent re-submission via the channels we DO use, and the existing per-run batch cap (250) is unchanged.

## Patch 2 — Empty affiliate-ID guard (+9 / -2)
**File:** `yalla_london/app/app/api/cron/affiliate-injection/route.ts`

Existing guard only caught params ending in `=`. Hardened to also reject multi-value templates with an empty middle segment, e.g. `?aid=&utm_source=site` (regex: `/[?&][^=&]+=(?=$|&)/`). Prevents dead-link injection when ANY env var in a multi-param template is blank — previously only the trailing one was caught.

## Patch 3 — hreflang on parent-brand portal (+5 / -1)
**File:** `yalla_london/app/app/page.tsx`

Article, blog list/category, journal, destinations, team, layout, and per-page metadata across the YL codebase already wire hreflang via `getLocaleAlternates()` — verified by codebase audit. Only the Zenitha.Luxury parent-brand portal was returning `alternates: { canonical: baseUrl }` (no language siblings), hiding the AR landing from Google's hreflang graph. Reuses the existing `rootAlternates` value already computed earlier in `generateMetadata()` — no new helper, no new state.

(No additional public-facing pages found with `generateMetadata` lacking alternates after audit. `inquiry/confirmation` is `robots: noindex`; user account pages — shop/download, shop/purchases, offline — are auth-gated. Both expected. If a translation-pair gap surfaces post-merge, it's a per-route follow-up rather than a layer fix.)

## Patch 4 — Image-pipeline inline backfill (+84 / 0)
**File:** `yalla_london/app/app/api/cron/image-pipeline/route.ts`

New `Step 1.7` between the existing photo-order processor (Step 1.5) and library pre-stock (Step 2). Each cron invocation finds up to 20 published `BlogPost`s whose `content_en` contains no `<img` tag, fetches one topical Unsplash photo via the existing `searchPhotos` + `buildImageUrl` helpers, builds a `<figure>` with attribution, and splices after the first `</p>` (prepends if none). Reuses `saveToLibrary` for media dedup. Cap = 20 per run across all sites — stays well within the 280s budget and Unsplash 50 req/hr free tier (with ~15 req from Step 1 + ~5 from Step 2 already accounted for). No new model integration, no schema changes.

## RLS Batch A — `prisma/migrations/20260610_rls_batch_a/migration.sql`

`ALTER TABLE ... ENABLE ROW LEVEL SECURITY;` on six tables, no policies — matches the existing YL convention (Supabase `service_role` bypasses RLS, Prisma client unaffected).

| Table | Status | Pre-flight |
|---|---|---|
| `google_drive_accounts` | included — highest priority (OAuth token leak) | no `supabase.from()` calls reach it |
| `finance_events` | included | clean |
| `agent_tasks` | included | clean |
| `daily_briefings` | included | clean |
| `chrome_audit_reports` | included | clean |
| `unsplash_cache` | included | clean |

**Held back from Batch A:** none. Phase 4 audit (`rg "supabase\.from\(['\"](google_drive_accounts|finance_events|agent_tasks|daily_briefings|chrome_audit_reports|unsplash_cache)['\"]\)"`) returned zero matches across `.ts`/`.tsx`. `NEXT_PUBLIC_SUPABASE_ANON_KEY` references in the codebase are limited to env validation/health-check endpoints, not table reads. Safe to enable RLS on all six.

## Not done (out of scope)
- Migration is NOT applied here. Vercel/CI runs `prisma migrate deploy` on next deploy.
- `.github/workflows/*` untouched (no Workflows permission on this PAT).
- `docs/leverage-ledger.md` untouched.

## Conventions observed
- Migrations live at `yalla_london/app/prisma/migrations/<YYYYMMDD>_<slug>/migration.sql` (raw SQL + Prisma migrate, no `migration_lock.toml` in the tree).
- AR routes are URL-prefix-rewritten via `middleware.ts` (no separate `/ar` folder). Hreflang is sourced from `lib/url-utils.ts::getLocaleAlternates()`.
- Service-role bypass for Supabase RLS is the established pattern for this repo — Prisma connects with `DATABASE_URL` (service-role).

**Do not merge.** Khaled merges.
