### PR TITLE
ops: add YL migration runner so prisma/migrations/*.sql auto-apply on deploy

### DIFF
--- a/yalla_london/app/package.json
+++ b/yalla_london/app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "(bash scripts/deploy-migrations.sh || echo 'Migrations skipped during build') && node scripts/prepare-build.js && next build",
+    "build": "(bash scripts/deploy-migrations.sh || echo 'Migrations skipped during build') && node scripts/apply-yl-migrations.mjs && node scripts/prepare-build.js && next build",
     "build:deps": "npx prisma generate --schema prisma/schema.prisma || echo 'Prisma generation failed, continuing with existing client'",
     "build:prisma": "npx prisma generate --schema prisma/schema.prisma",
     "start": "next start",

--- a/yalla_london/app/scripts/apply-yl-migrations.mjs
+++ b/yalla_london/app/scripts/apply-yl-migrations.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * YL custom migration runner ("Option B-light")
+ * ------------------------------------------------
+ * Auto-applies raw SQL migrations under prisma/migrations/<dir>/migration.sql on every
+ * Vercel deploy, WITHOUT using Prisma's native migration system.
+ *
+ * Background: YL's migrations are hand-authored raw SQL with no migration_lock.toml, and
+ * historically were applied out-of-band (Supabase MCP / SQL editor). `prisma migrate deploy`
+ * was never able to run them. This runner gives us a simple, low-risk, idempotent mechanism:
+ *
+ *   - A bookkeeping table `public._yl_migrations_applied` tracks which migration dirs ran.
+ *   - On the VERY FIRST run (table just created, zero rows) it GRANDFATHERS every existing
+ *     migration dir as already-applied, so we never re-run SQL that was applied by hand.
+ *   - Thereafter, any migration dir not yet recorded is executed inside a single transaction
+ *     and recorded. A SQL error rolls back and fails the build (exit 1).
+ *
+ * Going forward: drop a new prisma/migrations/<YYYYMMDD>_<slug>/migration.sql and it auto-applies
+ * on the next deploy. No more out-of-band application.
+ *
+ * Runs via package.json "build" before `next build`. Uses `pg` (already a runtime dep).
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+const { Client } = pg;
+const TAG = '[yl-migrations]';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = join(__dirname, '..', 'prisma', 'migrations');
+
+function log(msg) {
+  console.log(`${TAG} ${msg}`);
+}
+
+function fail(msg) {
+  console.error(`${TAG} ERROR: ${msg}`);
+}
+
+/** Migration directory names (sorted) that actually contain a migration.sql. */
+function listMigrationDirs() {
+  if (!existsSync(MIGRATIONS_DIR)) return [];
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((name) => {
+      const full = join(MIGRATIONS_DIR, name);
+      // Only directories (skips stray files like add-seo-tables.sql).
+      if (!statSync(full).isDirectory()) return false;
+      return existsSync(join(full, 'migration.sql'));
+    })
+    .sort(); // YYYYMMDD prefix gives natural chronological order.
+}
+
+function buildSslConfig(connectionString) {
+  const lower = connectionString.toLowerCase();
+  const isLocal = lower.includes('localhost') || lower.includes('127.0.0.1');
+  if (isLocal || lower.includes('sslmode=disable')) return false;
+  // Supabase / hosted Postgres require SSL; don't reject self-signed chain in the pooler.
+  return { rejectUnauthorized: false };
+}
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    // No DB available at build time (e.g. an env without DATABASE_URL). Skip without
+    // breaking the build — mirrors the legacy deploy-migrations.sh graceful-skip behavior.
+    log('DATABASE_URL not set, skipping migration runner');
+    return;
+  }
+
+  const dirs = listMigrationDirs();
+
+  const client = new Client({
+    connectionString,
+    ssl: buildSslConfig(connectionString),
+  });
+  await client.connect();
+
+  try {
+    // 1. Ensure bookkeeping table exists. Detect whether WE just created it.
+    const existed = await client.query(
+      `SELECT to_regclass('public._yl_migrations_applied') IS NOT NULL AS present`
+    );
+    const tablePreexisted = existed.rows[0].present === true;
+
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS public._yl_migrations_applied (
+        name TEXT PRIMARY KEY,
+        applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+    `);
+
+    let appliedRows = await client.query(
+      `SELECT name FROM public._yl_migrations_applied`
+    );
+
+    // 2. First-run bootstrap: table is brand-new AND empty -> grandfather everything.
+    const isFirstRun = !tablePreexisted && appliedRows.rowCount === 0;
+    if (isFirstRun) {
+      log('Created bookkeeping table');
+      if (dirs.length > 0) {
+        // Insert all existing migration dir names as already-applied in one statement.
+        const values = dirs.map((_, i) => `($${i + 1})`).join(', ');
+        await client.query(
+          `INSERT INTO public._yl_migrations_applied (name) VALUES ${values}
+           ON CONFLICT (name) DO NOTHING`,
+          dirs
+        );
+      }
+      log(`Grandfathered ${dirs.length} existing migrations`);
+      appliedRows = await client.query(
+        `SELECT name FROM public._yl_migrations_applied`
+      );
+    }
+
+    const applied = new Set(appliedRows.rows.map((r) => r.name));
+
+    // 3. Apply any migration dir not yet recorded.
+    const pending = dirs.filter((name) => !applied.has(name));
+    if (pending.length === 0) {
+      log('Nothing to apply');
+      return;
+    }
+
+    for (const name of pending) {
+      const sqlPath = join(MIGRATIONS_DIR, name, 'migration.sql');
+      const sql = readFileSync(sqlPath, 'utf8');
+      log(`Applying ${name}`);
+      try {
+        await client.query('BEGIN');
+        await client.query(sql); // simple protocol -> multi-statement file runs as one batch
+        await client.query(
+          `INSERT INTO public._yl_migrations_applied (name) VALUES ($1)`,
+          [name]
+        );
+        await client.query('COMMIT');
+        log(`OK ${name}`);
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {});
+        fail(`Failed applying ${name}: ${err && err.message ? err.message : err}`);
+        throw err;
+      }
+    }
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+main().catch((err) => {
+  fail(err && err.stack ? err.stack : String(err));
+  process.exit(1);
+});

--- a/yalla_london/app/scripts/apply-yl-migrations.mjs
+++ b/yalla_london/app/scripts/apply-yl-migrations.mjs
@@ -57,8 +57,23 @@ function buildSslConfig(connectionString) {
   const lower = connectionString.toLowerCase();
   const isLocal = lower.includes('localhost') || lower.includes('127.0.0.1');
   if (isLocal || lower.includes('sslmode=disable')) return false;
-  // Supabase / hosted Postgres require SSL; don't reject self-signed chain in the pooler.
+  // Supabase / hosted Postgres require SSL; don't reject the self-signed chain its
+  // pooler presents (Node's trust store doesn't include it).
   return { rejectUnauthorized: false };
+}
+
+/**
+ * Remove sslmode/ssl query params from the connection string. Under pg >= 8.18 a
+ * `sslmode=require` in DATABASE_URL re-enables certificate verification and overrides
+ * the explicit `ssl: { rejectUnauthorized: false }` Client option — Supabase then fails
+ * with "self-signed certificate in certificate chain". Stripping the param lets our
+ * explicit ssl config win. The password is left untouched (only the sslmode token goes).
+ */
+function stripSslParams(connectionString) {
+  let out = connectionString
+    .replace(/\bsslmode=[^&\s]*/gi, '')
+    .replace(/\bssl=[^&\s]*/gi, '');
+  return out.replace(/\?&/g, '?').replace(/&{2,}/g, '&').replace(/[?&]$/g, '');
 }
 
 async function main() {
@@ -73,7 +88,7 @@ async function main() {
   const dirs = listMigrationDirs();
 
   const client = new Client({
-    connectionString,
+    connectionString: stripSslParams(connectionString),
     ssl: buildSslConfig(connectionString),
     connectionTimeoutMillis: 15000,
     statement_timeout: 120000,

--- a/yalla_london/app/scripts/apply-yl-migrations.mjs
+++ b/yalla_london/app/scripts/apply-yl-migrations.mjs
@@ -75,8 +75,23 @@ async function main() {
   const client = new Client({
     connectionString,
     ssl: buildSslConfig(connectionString),
+    connectionTimeoutMillis: 15000,
+    statement_timeout: 120000,
   });
-  await client.connect();
+
+  // Connection/environment failures (DB unreachable at build time) must NOT break the
+  // build — this project's Vercel build cannot always reach the database (the legacy
+  // deploy-migrations.sh is wrapped in `|| echo` for exactly this reason). We skip loudly
+  // and the migration will auto-apply on the next deploy where the DB is reachable.
+  // A genuine migration SQL failure (below) is different and DOES fail the build (exit 1).
+  try {
+    await client.connect();
+  } catch (err) {
+    const msg = err && err.message ? err.message : String(err);
+    log(`Could not connect to DATABASE_URL (${msg}) — skipping migration runner; will apply on a deploy with DB access`);
+    await client.end().catch(() => {});
+    return;
+  }
 
   try {
     // 1. Ensure bookkeeping table exists. Detect whether WE just created it.


### PR DESCRIPTION
## Context

YL's database migrations live as **raw SQL** under `yalla_london/app/prisma/migrations/<YYYYMMDD>_<slug>/migration.sql`. There's no `migration_lock.toml` and the project has never used Prisma's native migration tracking — past migrations were applied **by hand** (Supabase MCP / SQL editor). The existing `deploy-migrations.sh` build step runs `npx prisma migrate deploy`, but that path can't work without Prisma's `_prisma_migrations` bookkeeping, so it's effectively a silent no-op (it's wrapped in `|| echo 'Migrations skipped'`).

The trigger: PR #803 added `prisma/migrations/20260610_rls_batch_a/migration.sql` (6 `ALTER TABLE … ENABLE ROW LEVEL SECURITY` statements) but it was **never auto-applied** — it had to be run out-of-band via Supabase MCP. This PR makes future migrations apply themselves on deploy. (Operator chose this "Option B-light" over a full Prisma-native conversion because it's lower risk and needs no operator-side baselining.)

## What this adds

**`yalla_london/app/scripts/apply-yl-migrations.mjs`** — a small `pg`-based runner (uses the existing `pg` runtime dep; no new deps) that runs in the Vercel build via `package.json`'s `build` script, **before** `next build`:

```
"build": "(bash scripts/deploy-migrations.sh || echo 'Migrations skipped during build') && node scripts/apply-yl-migrations.mjs && node scripts/prepare-build.js && next build"
```

(The legacy `deploy-migrations.sh` step is left untouched — it remains a harmless no-op; the new runner is the authoritative mechanism.)

### Runner behaviour

1. Connects via `process.env.DATABASE_URL` (Vercel injects it at build time). If `DATABASE_URL` is absent, it logs and skips cleanly so a DB-less build never breaks.
2. Ensures a bookkeeping table exists:
   ```sql
   CREATE TABLE IF NOT EXISTS public._yl_migrations_applied (
     name TEXT PRIMARY KEY,
     applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
   );
   ```
3. **First-run bootstrap (grandfathering):** when the table is brand-new and empty, every existing `prisma/migrations/*/` directory name is inserted as already-applied. This guarantees nothing that was applied by hand (including **RLS Batch A**) is ever re-run.
4. For each migration dir (sorted — the `YYYYMMDD` prefix gives natural order), if its name isn't recorded, it reads `migration.sql`, executes the whole file inside a single `BEGIN … COMMIT` transaction, then records the name. On any SQL error it `ROLLBACK`s, logs to stderr, and **exits 1 (fails the build)**.
5. Logs every action: `Created bookkeeping table`, `Grandfathered N existing migrations`, `Applying <name>`, `OK <name>`, `Nothing to apply`.

(The stray non-directory file `prisma/migrations/add-seo-tables.sql` is correctly skipped — only directories containing a `migration.sql` are considered.)

## How to use going forward

Drop a new `prisma/migrations/<YYYYMMDD>_<slug>/migration.sql` and it auto-applies on the next deploy. No more out-of-band Supabase MCP application — **future RLS batches B/C/D become a one-PR ship.**

## Rollback

Remove `node scripts/apply-yl-migrations.mjs &&` from the `build` script to disable the runner. The `_yl_migrations_applied` table is harmless if left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)