### PR TITLE
feat(seo): CTR title hardening + striking-distance internal linking

### DIFF
--- a/yalla_london/app/app/api/cron/seo-agent/route.ts
+++ b/yalla_london/app/app/api/cron/seo-agent/route.ts
@@ -355,11 +355,51 @@ async function runSEOAgent(prisma: any, siteId: string, siteUrl?: string) {
           .filter((p: { slug: string | null }) => p.slug)
           .map((p: { slug: string; title_en: string }) => ({ slug: p.slug, title: p.title_en }));
 
+        // June 13 2026 audit: internal links should flow to STRIKING-DISTANCE
+        // pages (avg position 4–20 with real impressions) — those are one push
+        // from page 1 / top 3, so an inbound link there converts to a measurable
+        // rank gain. Previously targets were arbitrary recent/old posts. Build a
+        // priority set from the last 28 days of GSC data and link to those first.
+        const strikingSlugs = new Set<string>();
+        try {
+          const gscRows = await prisma.gscPagePerformance.findMany({
+            where: {
+              site_id: siteId,
+              date: { gte: new Date(Date.now() - 28 * 24 * 60 * 60 * 1000) },
+            },
+            select: { url: true, impressions: true, position: true },
+          });
+          const agg = new Map<string, { impr: number; posSum: number; n: number }>();
+          for (const r of gscRows as Array<{ url: string; impressions: number; position: number }>) {
+            const m = r.url.match(/\/blog\/([^/?#]+)/);
+            if (!m || r.url.includes("/ar/")) continue;
+            const cur = agg.get(m[1]) || { impr: 0, posSum: 0, n: 0 };
+            cur.impr += r.impressions || 0;
+            cur.posSum += (r.position || 0) * (r.impressions || 1);
+            cur.n += r.impressions || 1;
+            agg.set(m[1], cur);
+          }
+          for (const [slug, v] of agg) {
+            const avgPos = v.posSum / Math.max(1, v.n);
+            if (v.impr >= 10 && avgPos > 3.5 && avgPos <= 20) strikingSlugs.add(slug);
+          }
+        } catch (gscErr) {
+          console.warn("[seo-agent] striking-distance target query failed (non-fatal):", (gscErr as Error).message);
+        }
+
         for (const post of needsLinks.slice(0, 25)) {
           if (!post.content_en || post.content_en.length < 200) continue;
 
-          // Find 3 related posts (different slug, has title)
-          const relatedCandidates = publishedSlugs.filter((p: { slug: string }) => p.slug !== post.slug).slice(0, 6);
+          // Find 3 related posts (different slug, has title) — striking-distance
+          // targets first so internal authority pushes near-page-1 pages upward.
+          const relatedCandidates = publishedSlugs
+            .filter((p: { slug: string }) => p.slug !== post.slug)
+            .sort((a: { slug: string }, b: { slug: string }) => {
+              const aPri = strikingSlugs.has(a.slug) ? 0 : 1;
+              const bPri = strikingSlugs.has(b.slug) ? 0 : 1;
+              return aPri - bPri;
+            })
+            .slice(0, 6);
 
           if (relatedCandidates.length < 2) continue;
 

--- a/yalla_london/app/docs/AUDIT-LOG.md
+++ b/yalla_london/app/docs/AUDIT-LOG.md
@@ -1722,3 +1722,29 @@ Total test suite: 90 tests across 16 categories.
 - **Updated by:** Claude Code during each audit session
 - **Referenced by:** CLAUDE.md, future audit runs
 - **Format:** Each audit gets a section with numbered findings (A{audit#}-{seq})
+
+---
+
+## Session: June 13, 2026 — SEO/AIO Performance Audit & 10-Improvement Sprint
+
+**Diagnosis (from live GSC + DB, last 28d):** Site is NOT failing to rank — 238 pages sit on page 1 (19 at pos 1–3, 219 at pos 4–10), avg position 12.6, 367 pages with impressions, 20,112 impressions / 409 clicks. The real bottlenecks were **CTR (2.0% vs expected 5–8% for these positions)** and **topical dilution**, not indexing.
+
+**Root causes found:**
+1. Systemic title truncation — `daily-content-generate` + `auto-seo-service` cut titles mid-word ("…Luxury Guide for", "…Rituals in") and `sanitizeTitle` left dangling stopwords after its 60-char cut.
+2. Baked-in "| Yalla London" brand suffix → SERP shows "…| Yalla" when length-capped.
+3. Stale dates in 39 titles (2024/2025) + 25 month references suppressing CTR.
+4. Live cannibalization clusters (afternoon-tea, novikov, spas, fine-dining, ajwa, edgware, ramadan, islamic-heritage) splitting impressions.
+5. Wrong meta titles (breakfast page → "Fine Dining", edgware → "Novikov") + 7 posts with English text in `title_ar`.
+6. `#1 impression page` (`which-tube-lines…-v2`, 4,521 impr, pos 8.7) stuck at 0.58% CTR on a stale "May…Luxury Guide" title.
+
+**Executed (10 improvements):**
+- **DB (immediate, measurable in GSC within days):** consolidated 15 duplicates → 7 winners via `canonical_slug` 301; cleaned stale years/brand suffixes/truncations on all titles + meta titles; hand-rewrote CTR titles + fixed meta mismatches on top 7 pages; translated 7 English `title_ar` to Arabic + fixed edgware meta leak; cleaned 63 meta descriptions (literal newlines, stale years); queued changed URLs for IndexNow re-crawl.
+- **Code (durable, prevents regression):** hardened `sanitizeTitle` (TRAILING_BRAND + TRAILING_DANGLING_WORD, word-boundary truncation) + `hasTitleArtifacts` detection (feeds pre-pub gate); replaced ellipsis/mid-word truncation in `auto-seo-service.optimizeTitle`; **seo-agent internal-link targets now prioritize striking-distance pages (GSC pos 4–20 w/ impressions)** so internal authority pushes near-page-1 pages upward.
+
+**Verification:** 0 stale-year titles, 0 brand/dangling titles, 0 `title_ar` Latin contamination, 0 newline meta descriptions remaining. TypeScript: 0 errors repo-wide.
+
+**Critical Rules Learned:**
+- Title truncation has TWO sources — hard `slice(0,60)` in generators AND word-boundary cuts that leave dangling stopwords. The shared `sanitizeTitle` must strip trailing connectives after ANY cut; generators must route through it.
+- Never bake "| Yalla London" into a title — Google appends the site name automatically; the baked suffix gets cut to "…| Yalla" under length caps.
+- Internal-link TARGET selection is a ranking lever: link to GSC striking-distance pages (pos 4–20 with impressions), not arbitrary recent posts.
+- For a site already ranking, CTR (titles/meta) + cannibalization consolidation move the needle faster than more content.

--- a/yalla_london/app/lib/content-pipeline/title-sanitizer.ts
+++ b/yalla_london/app/lib/content-pipeline/title-sanitizer.ts
@@ -61,6 +61,21 @@ const TRAILING_COLON = /\s*:\s*$/;
 // Trailing comma/semicolon (Marathon: "Training,") — May 17 2026 re-audit
 const TRAILING_PUNCTUATION = /\s*[,;]+\s*$/;
 
+// Brand suffix the AI sometimes bakes into the title. Google appends the site
+// name automatically, so "Title | Yalla London" shows as "Title | Yalla London
+// | Yalla London" in the SERP, AND when titles are length-capped the brand text
+// gets cut to "...| Yalla" — a CTR killer. Strip any trailing Yalla[ London].
+// (June 13 2026 audit: 40+ live titles ended in "| Yalla" or "| Yalla London".)
+const TRAILING_BRAND = /\s*[|–-]\s*Yalla(\s+London)?\s*$/i;
+
+// Dangling connective/stopword left at the end after a hard length truncation,
+// e.g. "...Luxury Guide for", "...Authentic Rituals in", "...Need to". These
+// read as broken/incomplete in the SERP and suppress CTR. Strip the trailing
+// orphan word (run twice to catch "...Guide for the" → "...Guide").
+// (June 13 2026 audit root cause: daily-content-generate hard-sliced at 60 chars
+// mid-word; this is the safety net so the artifact never ships again.)
+const TRAILING_DANGLING_WORD = /\s+(?:for|to|in|and|with|the|of|a|an|your|like|by|on|at|from|that|as|or|but|into|about)$/i;
+
 // Versioning slugs leaked from content-strategy ("V2", "V3", "(v2)", "-v3", "Version 2")
 // Lookahead keeps colon-separated subtitles intact: matches " V2" only before ":" or end-of-string.
 // Examples stripped: "Best London Hotels V2: Ultimate", "Guide v3", "Title (V2)"
@@ -143,7 +158,16 @@ export function sanitizeTitle(title: string): string {
   // Re-collapse whitespace after stripping (placeholders may leave double spaces)
   cleaned = cleaned.replace(/\s{2,}/g, " ").trim();
 
+  // Strip baked-in brand suffix ("| Yalla London") — Google adds it automatically
+  cleaned = cleaned.replace(TRAILING_BRAND, "").trim();
+
   // Strip trailing punctuation artifacts (e.g., " -" or " |" left after stripping)
+  cleaned = cleaned.replace(/\s*[|–-]\s*$/, "").trim();
+
+  // Strip a dangling connective word left by an upstream hard truncation
+  // (twice, to unwind "...Guide for the" → "...Guide")
+  cleaned = cleaned.replace(TRAILING_DANGLING_WORD, "").trim();
+  cleaned = cleaned.replace(TRAILING_DANGLING_WORD, "").trim();
   cleaned = cleaned.replace(/\s*[|–-]\s*$/, "").trim();
 
   // Collapse duplicated subtitle ("Best Hotels - Best Hotels Guide" → "Best Hotels")
@@ -152,11 +176,15 @@ export function sanitizeTitle(title: string): string {
     cleaned = dupMatch[1].trim();
   }
 
-  // Enforce max 60 chars (truncate at word boundary)
+  // Enforce max 60 chars (truncate at word boundary, never mid-word)
   if (cleaned.length > 60) {
-    const truncated = cleaned.substring(0, 57);
+    const truncated = cleaned.substring(0, 60);
     const lastSpace = truncated.lastIndexOf(" ");
     cleaned = lastSpace > 20 ? truncated.substring(0, lastSpace) : truncated;
+    // A word-boundary cut can leave a dangling connective ("...Guide for") —
+    // strip it so the capped title still reads as a complete phrase.
+    cleaned = cleaned.replace(TRAILING_DANGLING_WORD, "").trim();
+    cleaned = cleaned.replace(/\s*[|–:,-]\s*$/, "").trim();
   }
 
   return cleaned;
@@ -275,6 +303,9 @@ export function hasTitleArtifacts(title: string): boolean {
     TRAILING_PUNCTUATION.test(title) ||
     VERSION_SUFFIX.test(title) ||
     BRACKET_PLACEHOLDER.test(title) ||
+    // June 13 2026 audit: baked-in brand suffix + truncation artifacts
+    TRAILING_BRAND.test(title) ||
+    TRAILING_DANGLING_WORD.test(title) ||
     // Starts with "EXPAND:" leak from content-strategy
     /^EXPAND:\s*/i.test(title)
   );

--- a/yalla_london/app/lib/seo/auto-seo-service.ts
+++ b/yalla_london/app/lib/seo/auto-seo-service.ts
@@ -422,9 +422,15 @@ export class AutoSEOService {
     if (title.length <= maxLength) {
       return title;
     }
-    
-    // Truncate and add ellipsis
-    return title.substring(0, maxLength - 3) + '...';
+
+    // Truncate at the last word boundary (never mid-word, never an ellipsis —
+    // ellipsis + mid-word cuts read as broken in the SERP and suppress CTR).
+    const cut = title.substring(0, maxLength);
+    const lastSpace = cut.lastIndexOf(' ');
+    let out = lastSpace > maxLength * 0.5 ? cut.substring(0, lastSpace) : cut;
+    // Strip a trailing connective left by the cut ("...Guide for" → "...Guide")
+    out = out.replace(/\s+(?:for|to|in|and|with|the|of|a|an|by|on|at|from|or)$/i, '').trim();
+    return out.replace(/\s*[|–:,-]\s*$/, '').trim();
   }
 
   /**


### PR DESCRIPTION
- title-sanitizer: strip baked-in '| Yalla London' brand suffix and trailing
  dangling stopwords left by hard truncation; word-boundary cap; flag both in
  hasTitleArtifacts (feeds pre-publication gate)
- auto-seo-service.optimizeTitle: word-boundary truncation, no mid-word ellipsis
- seo-agent: internal-link targets now prioritize striking-distance pages
  (GSC avg position 4-20 with impressions) so internal authority pushes
  near-page-1 pages upward instead of linking to arbitrary recent posts

Root cause of 60+ truncated/stale live titles ('...Guide for', '...| Yalla').
Companion DB cleanup (cannibalization consolidation, stale-date/meta fixes,
Arabic title fixes, re-crawl queue) applied to production.